### PR TITLE
Update load time condition and ticket table headers

### DIFF
--- a/app/javascript/loading.js.erb
+++ b/app/javascript/loading.js.erb
@@ -3,7 +3,7 @@ document.addEventListener('turbo:load', () => {
   const includedPaths = [ '/' ];
   const loadTime = performance.timing.loadEventEnd - performance.timing.navigationStart;
 
-  if (!includedPaths.includes(window.location.pathname) && loadTime <= 2000) {
+  if (!includedPaths.includes(window.location.pathname) && loadTime <= 5000) {
     return;
   }
 

--- a/app/views/tickets/_ticket.html.erb
+++ b/app/views/tickets/_ticket.html.erb
@@ -3,10 +3,10 @@
     <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
     <tr>
       <th scope="col" class="px-2 py-2">
-        Ticket ID
+        Date of Issue
       </th>
       <th scope="col" class="px-2 py-2">
-        Date of Issue
+        Ticket ID
       </th>
       <th scope="col" class="px-2 py-2">
         Issue


### PR DESCRIPTION
Extend the allowed load time duration in `loading.js.erb` from 2 seconds to 5 seconds. Swap the headers for Ticket ID and Date of Issue in the tickets partial view for better clarity.