### PR TITLE
Make client association optional in Project model

### DIFF
--- a/app/controllers/client_controller.rb
+++ b/app/controllers/client_controller.rb
@@ -59,6 +59,13 @@ class ClientController < ApplicationController
     end
   end
 
+  def destroy
+    @client.destroy
+    respond_to do |format|
+      format.html { redirect_to client_index_path, notice: 'Client was successfully destroyed.' }
+    end
+  end
+
   private
 
   def set_client

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,7 +1,7 @@
 class Client < ApplicationRecord
   belongs_to :user
-  has_many :projects
-  has_many :products
+  has_many :projects, dependent: :destroy
+  has_many :products, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 50 }
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,7 +1,7 @@
 class Project < ApplicationRecord
   belongs_to :user
   belongs_to :software
-  belongs_to :client
+  belongs_to :client, optional: true
 
   has_many :tickets, dependent: :destroy
   has_many :issues, foreign_key: :project_id, class_name: 'Issue', dependent: :destroy

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,8 +13,6 @@
   <%= javascript_importmap_tags %>
   <%= Sentry.get_trace_propagation_meta.html_safe %>
   <%= javascript_include_tag "controllers/tribute_controller", defer: true %>
-  <script src="https://cdn.jsdelivr.net/npm/tributejs/dist/tribute.min.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tributejs/dist/tribute.css"/>
 </head>
 
 <body class="bg-slate-100 dark:bg-gray-900 text-gray-900 dark:text-slate-100">


### PR DESCRIPTION
This pull request updates the Project model to allow projects without an associated client by making the client association optional. Additionally, it includes a destroy action in the Client controller for proper deletion of associated projects and products when a client is destroyed. Unused Tribute.js script and stylesheets are also cleaned up from the application layout.