### PR TITLE
Remove unused import from application.js

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,7 +9,6 @@ import '@rails/actiontext';
 //= require_tree .
 //= require 'chartkick'
 //= require 'chart.js'
-import "./controllers/groupware_controller";
 
 import "trix"
 import "@rails/actiontext"


### PR DESCRIPTION
The import of groupware_controller was removed because it is no longer used in the application.js file. This change helps to clean up the codebase and improve overall maintainability. Import statements should only include necessary modules to avoid potential confusion and reduce unnecessary dependencies.