### PR TITLE
Adding the back button

### DIFF
--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -11,12 +11,12 @@
         <!-- Firstname field -->
         <div class="field flex gap-2 m-2">
           <%= f.label :first_name, class: 'pt-3' %>
-          <%= f.text_field :first_name, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-[250px] dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'First Name', required: true %>
+          <%= f.text_field :first_name, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-[250px] dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'First Name' %>
         </div>
         <!-- Lastname field -->
         <div class="field flex gap-2 m-2">
           <%= f.label :last_name, class: 'pt-3' %>
-          <%= f.text_field :last_name, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-[250px] dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Last Name', required: true %>
+          <%= f.text_field :last_name, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-[250px] dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Last Name'%>
         </div>
       </div>
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module Cspm
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
     config.time_zone = 'Africa/Nairobi'
-    config.active_record.default_timezone = :local
+    # config.active_record.default_timezone = :local
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
This pull request includes changes to the `app/views/devise/invitations/new.html.erb` and `config/application.rb` files. The changes primarily involve modifying form field requirements and adjusting the timezone configuration.

Changes to form fields:

* [`app/views/devise/invitations/new.html.erb`](diffhunk://#diff-f8163cf150217d1849f57d58f742bbaf624a0699caf0e9d9d7d5fb936726b7f6L14-R19): Removed the `required` attribute from the `first_name` and `last_name` fields in the invitation form.

Timezone configuration adjustments:

* [`config/application.rb`](diffhunk://#diff-c1fd91cb1911a0512578b99f657554526f3e1421decdb9e908712beab57e10f9L19-R19): Commented out the line setting `config.active_record.default_timezone` to `:local`, which means it will now use the default setting.