### PR TITLE
Adding the back button

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,8 @@ module Cspm
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
     config.time_zone = 'Africa/Nairobi'
-    config.active_record.default_timezone = :local
+
+    config.active_record.default_timezone = :utc
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
This pull request includes a change to the `config/application.rb` file to update the default timezone configuration for Active Record. The most important change is:

* [`config/application.rb`](diffhunk://#diff-c1fd91cb1911a0512578b99f657554526f3e1421decdb9e908712beab57e10f9L19-R20): Modified `config.active_record.default_timezone` from `:local` to `:utc`.