### PR TITLE
Deploy cloudinary

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,7 +42,6 @@ set :keep_releases, 5
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure
 
-
 set :default_env, {
   'CLOUDINARY_CLOUD_NAME' => 'dvplan8dp',
   'CLOUDINARY_API_KEY' => 'y623452783817565',

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -43,3 +43,8 @@ set :keep_releases, 5
 # set :ssh_options, verify_host_key: :secure
 
 
+set :default_env, {
+  'CLOUDINARY_CLOUD_NAME' => 'dvplan8dp',
+  'CLOUDINARY_API_KEY' => 'y623452783817565',
+  'CLOUDINARY_API_SECRET' => 'WeHl8NTZLQGyKx8psN8ZsmLbyxUs'
+}


### PR DESCRIPTION
This pull request includes a critical configuration update to the deployment settings. The most important change involves setting environment variables for Cloudinary.

Configuration updates:

* [`config/deploy.rb`](diffhunk://#diff-3d066bc83eaf220ed7d8276202a78415dfe66ddf285f3382273b86d5845ab9c4L45-R49): Added default environment variables for `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, and `CLOUDINARY_API_SECRET` to the deployment configuration.