### PR TITLE
Add all list

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,8 +42,4 @@ set :keep_releases, 5
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure
 
-set :default_env, {
-  'CLOUDINARY_CLOUD_NAME' => 'dvplan8dp',
-  'CLOUDINARY_API_KEY' => 'y623452783817565',
-  'CLOUDINARY_API_SECRET' => 'WeHl8NTZLQGyKx8psN8ZsmLbyxUs'
-}
+

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,13 +8,6 @@ local:
 
 
 # Use the credentials file for the production environment
-cloudinary:
-  service: Cloudinary
-  cloud_name: <%= ENV.fetch('CLOUDINARY_CLOUD_NAME') %>
-  api_key: <%= ENV.fetch('CLOUDINARY_API_KEY' )%>
-  api_secret: <%= ENV.fetch('CLOUDINARY_API_SECRET') %>
-  enhance_image_tag: true
-  static_file_support: false
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
This pull request includes changes to remove Cloudinary configuration from the deployment and storage settings. The most important changes involve the removal of environment variables and service configuration related to Cloudinary.

Configuration changes:

* [`config/deploy.rb`](diffhunk://#diff-3d066bc83eaf220ed7d8276202a78415dfe66ddf285f3382273b86d5845ab9c4L45-R45): Removed the default environment variables for Cloudinary (`CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`).
* [`config/storage.yml`](diffhunk://#diff-188abe2a4493506d81577fbbee0b279b889e59f50d509402fbbfb620c8e58780L11-L17): Removed the Cloudinary service configuration, including `cloud_name`, `api_key`, `api_secret`, `enhance_image_tag`, and `static_file_support` settings.