### PR TITLE
Enable multi-select for product categories and extend character limit

### DIFF
--- a/app/views/project/edit.html.erb
+++ b/app/views/project/edit.html.erb
@@ -16,13 +16,11 @@
           <%= f.select :user_id, User.with_agent_project_manager_role.order(:first_name, :last_name).map { |user| [user.name, user.id] }, {},class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Assign User', required: true %>
         </div>
         <div class="relative z-0 w-full mb-6 group">
-          <%= f.label :software, ('Product Categories *'), class: "capitalize block mb-1 text-sm font-medium" %>
-          <%= f.collection_select :software_id, Software.all, :id, :name, { prompt: "Select Product" }, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", data: { action: "change->form#updateGroupwareOptions" } %>
-        </div>
-
-        <div class="relative z-0 w-full mb-6 group">
-          <%= f.label :software, ('Sub Product *'), class: "capitalize block mb-1 text-sm font-medium" %>
-          <%= f.collection_select :groupware_id, Groupware.distinct, :id, :name, { prompt: "Select The Product" }, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", id: "groupware-select" %>
+          <%= f.label :categories, ('Product Categories *'), class: "capitalize block mb-1 text-sm font-medium" %>
+          <%= f.collection_select :software_ids, Software.all, :id, :name,
+                                  { prompt: "Select Product", include_hidden: false },
+                                  class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500",
+                                  multiple: true %>
         </div>
       </div>
       <div class="grid grid-cols-2 gap-2">
@@ -37,8 +35,8 @@
       </div>
       <div class="relative z-0 w-full mb-6 group">
         <%= f.label :title, ('Subject *'), class: "capitalize block mb-1 text-sm font-medium" %><br />
-        <div data-controller="text-limit" data-text-limit-limit-value="800">
-          <p id="char-count">0/800</p>
+        <div data-controller="text-limit" data-text-limit-limit-value="1200">
+          <p id="char-count">0/1200</p>
           <%= f.rich_text_area :content, id: "content",
                                data: { text_limit_target: "content" },
                                class: "min-h-[300px] #{'border-red-500' if @project.errors[:content].any?}",

--- a/app/views/project/new.html.erb
+++ b/app/views/project/new.html.erb
@@ -26,9 +26,9 @@
         </div>
         <div class="relative z-0 w-full mb-6 group">
           <%= f.label :categories, ('Product Categories *'), class: "capitalize block mb-1 text-sm font-medium" %>
-          <%= f.collection_select :software_ids, Software.all, :id, :name, 
-                                  { prompt: "Select Product", include_hidden: false }, 
-                                  class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", 
+          <%= f.collection_select :software_ids, Software.all, :id, :name,
+                                  { prompt: "Select Product", include_hidden: false },
+                                  class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500",
                                   multiple: true %>
         </div>
       </div>
@@ -55,7 +55,6 @@
           <% end %>
         </div>
       </div>
-
     </div>
     <%= f.submit  class: 'mb-4 h-12 border border-black dark:border-white border-b-4 border-r-2 p-3 rounded font-semibold rounded'  %>
   <% end %>


### PR DESCRIPTION
**Description:**
Updated `collection_select` fields in "new" and "edit" views to allow selecting multiple product categories instead of a single one. Additionally, increased the character limit for the "Subject" field from 800 to 1200 in the "edit" view. These changes improve flexibility and usability for project forms.