### PR TITLE
Set email open and read timeouts in production config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,7 +114,8 @@ Rails.application.configure do
     ssl: true, # Use SSL encryption
     tls: true, # Enforce TLS
     enable_starttls_auto: true, # Automatically start TLS if available
-    openssl_verify_mode: 'none' # To avoid certificate verification issues (use cautiously)
+    openssl_verify_mode: 'none', # To avoid certificate verification issues (use cautiously)
+    open_timeout: 30, # Increase open timeout to 30 seconds
+    read_timeout: 30  # I
   }
-
 end


### PR DESCRIPTION
This pull request includes a change to the `config/environments/production.rb` file to enhance the email configuration by increasing the timeout settings.

Configuration improvements:

* [`config/environments/production.rb`](diffhunk://#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eL117-L119): Added `open_timeout` and `read_timeout` settings to the email configuration to improve connection reliability.Added `open_timeout` and `read_timeout` settings to the mailer configuration in the production environment. These changes aim to improve reliability by ensuring timeout limits for email connections are explicitly defined.