### PR TITLE
Switch Active Storage service to Cloudinary in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,7 +107,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address: 'secure.emailsrvr.com',
     port: 465, # Use 587 for STARTTLS or 465 for SSL/TLS
-    domain: 'https://taskbridge.craftsilicon.com/', # Replace with your domain
+    domain: 'https://taskbridge.craftsilicon.com', # Replace with your domain
     user_name: 'cspm@craftsilicon.com', # Replace with your email
     password: '#cspm@123#', # Replace with your email password
     authentication: 'plain', # Can also be 'plain' or 'cram_md5'

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -9,6 +9,13 @@ local:
 
 # Use the credentials file for the production environment
 
+
+cloudinary:
+  service: Cloudinary
+  cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
+  api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
+  api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
<details>
<summary>Details</summary>

- Updated the production environment to use Cloudinary for Active Storage, replacing the local file system.
- Added necessary configuration to `storage.yml`, leveraging environment variables for Cloudinary credentials.

</details>

This pull request includes changes to the production environment configuration to switch file storage to Cloudinary and correct a domain URL in the SMTP settings.

Changes to production environment configuration:

* [`config/environments/production.rb`](diffhunk://#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eL40-R40): Changed the `active_storage.service` from `:local` to `:cloudinary` to switch file storage to Cloudinary.
* [`config/environments/production.rb`](diffhunk://#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eL110-R110): Corrected the domain URL in `action_mailer.smtp_settings` by removing the trailing slash.
* [`config/storage.yml`](diffhunk://#diff-188abe2a4493506d81577fbbee0b279b889e59f50d509402fbbfb620c8e58780R12-R18): Added Cloudinary configuration details, including `cloud_name`, `api_key`, and `api_secret`.