### PR TITLE
Set up Cloudinary for Active Storage in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/initializers/cloudinary.rb
+++ b/config/initializers/cloudinary.rb
@@ -1,0 +1,6 @@
+Cloudinary.config do |config|
+  config.cloud_name = ENV['CLOUDINARY_CLOUD_NAME']
+  config.api_key = ENV['CLOUDINARY_API_KEY']
+  config.api_secret = ENV['CLOUDINARY_API_SECRET']
+  config.secure = true # Use HTTPS for all Cloudinary URLs
+end


### PR DESCRIPTION
Added a Cloudinary initializer to configure cloud storage with environment variables. Changed Active Storage service in the development environment to use Cloudinary instead of local storage. This enables secure HTTPS uploads and better cloud asset management.

This pull request includes changes to configure the application to use Cloudinary for file storage instead of the local file system. The most important changes include updating the storage service configuration and adding Cloudinary configuration settings.

Configuration changes:

* [`config/environments/development.rb`](diffhunk://#diff-d3c4b3f41072daa416f1920511e9b2e26caea8c5cec0a14cb9508589a4dafa47L37-R37): Changed the `active_storage.service` setting from `:local` to `:cloudinary` to switch the file storage service to Cloudinary.
* [`config/initializers/cloudinary.rb`](diffhunk://#diff-775eb3120d9e1df5ae1dfb71675c7ea4aae981998e64436b40fd6c03e5113d8aR1-R6): Added a new initializer to configure Cloudinary with environment variables for `cloud_name`, `api_key`, `api_secret`, and enabled secure URLs.