### PR TITLE
Set Active Storage service to local in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :cloudinary
+  config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
<details>
<summary>Details</summary>

Updated the Active Storage configuration to use the local file system instead of Cloudinary in the production environment. This change ensures that uploaded files are stored locally as specified in the environment configuration.

</details>

This pull request includes a change to the `config/environments/production.rb` file. The change modifies the configuration for storing uploaded files to use the local file system instead of Cloudinary.

Configuration changes:

* [`config/environments/production.rb`](diffhunk://#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eL40-R40): Changed `config.active_storage.service` from `:cloudinary` to `:local` to store uploaded files on the local file system.