### PR TITLE
Restrict access to Assigned Agents for admins and project managers

### DIFF
--- a/app/views/project/_assign_people.html.erb
+++ b/app/views/project/_assign_people.html.erb
@@ -1,3 +1,4 @@
+<% if current_user.has_role? :admin or current_user.has_role?('project manager') %>
 <h3>Assigned Agents</h3>
 <div class="flex flex-wrap gap-2">
   <% @project.users.each do |user| %>
@@ -10,3 +11,4 @@
     </p>
   <% end %>
 </div>
+<% end %>


### PR DESCRIPTION
- [ ] Implement access control to ensure only admins and project managers can view the list of assigned agents.

This pull request includes changes to the `app/views/project/_assign_people.html.erb` file to improve role-based access control. The most important changes are:

Role-based access control:

* Added a conditional to check if the current user has the role of `admin` or `project manager` before displaying the "Assigned Agents" section.
* Ensured the conditional block is properly closed after the "Assigned Agents" section.