### PR TITLE
Active store fix

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,8 @@ module Cspm
 
     config.active_storage.queues.analysis = :active_storage_analysis
     config.active_storage.queues.purge = :active_storage_purge
+    config.active_storage.service_urls_expire_in = 5.minutes
+    config.active_storage.service = :local
+
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :production
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,13 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+production:
+  service: Disk
+  root: /var/www/uploads
+
+
+
+
 
 # Use the credentials file for the production environment
 


### PR DESCRIPTION
This pull request includes changes to the Active Storage configuration in a Rails application. The most important changes involve setting the service URLs expiration time, modifying the storage service used in production, and updating the storage configuration file to include a production environment setup.

Active Storage configuration updates:

* [`config/application.rb`](diffhunk://#diff-c1fd91cb1911a0512578b99f657554526f3e1421decdb9e908712beab57e10f9R34-R36): Added configuration for `active_storage.service_urls_expire_in` to set the expiration time for service URLs to 5 minutes and specified the storage service as `:local`.
* [`config/environments/production.rb`](diffhunk://#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eL40-R40): Changed the Active Storage service from `:local` to `:production` for the production environment.
* [`config/storage.yml`](diffhunk://#diff-188abe2a4493506d81577fbbee0b279b889e59f50d509402fbbfb620c8e58780R9-R15): Added a new `production` section to configure the Active Storage service to use the local disk at `/var/www/uploads` in the production environment.