### PR TITLE
This is the fix to ensure a user is assigned by the product

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,8 +41,8 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  # config.action_cable.url = "wss://example.com/cable"
-  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+  config.action_cable.url = "wss://taskbridge.craftsilicon.com/cable"
+  config.action_cable.allowed_request_origins = [ "https://taskbridge.craftsilicon.com" ]
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.


### PR DESCRIPTION
This pull request includes changes to the `config/environments/production.rb` file to update the Action Cable configuration for the production environment.

Action Cable configuration updates:

* Updated `config.action_cable.url` to "wss://taskbridge.craftsilicon.com/cable".
* Updated `config.action_cable.allowed_request_origins` to include "https://taskbridge.craftsilicon.com".