### PR TITLE
Status clean up

### DIFF
--- a/app/views/tickets/_ticket_status.html.erb
+++ b/app/views/tickets/_ticket_status.html.erb
@@ -1,4 +1,6 @@
+<% if @ticket.statuses.present? %>
 <% @ticket.statuses.each do |status| %>
+
   <% case status.name %>
 <% when 'Resolved' %>
     <p class='bg-green-500 text-center text-slate-100 font-bold rounded p-1 border-r-2 border-b-4 border-green-600'>
@@ -49,4 +51,5 @@
       <%= status.name %>
     </p>
   <% end %>
+    <% end %>
 <% end %>


### PR DESCRIPTION
This pull request includes a small change to the `app/views/tickets/_ticket_status.html.erb` file. The change ensures that the block of code iterating over ticket statuses is only executed if the `@ticket.statuses` collection is present.

* [`app/views/tickets/_ticket_status.html.erb`](diffhunk://#diff-9f0a806b35ae34743896cba1a1a3c169a56e0278352a2f34f1bc77aea10da69bR1-R3): Added a condition to check for the presence of `@ticket.statuses` before iterating over it. [[1]](diffhunk://#diff-9f0a806b35ae34743896cba1a1a3c169a56e0278352a2f34f1bc77aea10da69bR1-R3) [[2]](diffhunk://#diff-9f0a806b35ae34743896cba1a1a3c169a56e0278352a2f34f1bc77aea10da69bR55)