### PR TITLE
This is a path fix

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,7 @@ local:
 
 production:
   service: Disk
-  root: /var/www/uploads/uploads
+  root: /var/www/uploads
 
 
 


### PR DESCRIPTION
This pull request includes a small change to the `config/storage.yml` file. The change modifies the file path for the production environment to remove a redundant directory level.

* [`config/storage.yml`](diffhunk://#diff-188abe2a4493506d81577fbbee0b279b889e59f50d509402fbbfb620c8e58780L11-R11): Updated the `root` path for the production environment to `/var/www/uploads` instead of `/var/www/uploads/uploads`.