### PR TITLE
This is a path fix

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -29,7 +29,7 @@ class InvitationsController < Devise::InvitationsController
         redirect_to users_path, notice: 'User has been invited successfully.'
       else
         flash.now[:alert] = 'There was an error inviting the user.'
-        render :new
+        redirect_to new_user_invitation_path
       end
     end
   end

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -27,7 +27,7 @@
         </div>
         <div class="field flex gap-2 m-2">
           <%= f.label ('Client Name*'), class: 'pt-3' %>
-          <%= f.select :client_id, options_from_collection_for_select(Client.all, :id, :name), { prompt: 'Select Client' }, class: " h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full" %>
+          <%= f.select :client_id, options_from_collection_for_select(Client.all, :id, :name), { prompt: 'Select Client' }, class: " h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg w-full", required: true %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
This pull request includes changes to improve the user experience when inviting users and creating new invitations. The most important changes include redirecting users to the new invitation form upon failure and making the client selection mandatory.

Improvements to user experience:

* [`app/controllers/invitations_controller.rb`](diffhunk://#diff-5bf8adb0f93ca29f0c85b3b26c8e2b5cf9bf88a2a412431e3f0138b2db992b05L32-R32): Modified the `create` action to redirect to `new_user_invitation_path` instead of rendering the `new` template when there is an error inviting the user.
* [`app/views/devise/invitations/new.html.erb`](diffhunk://#diff-f8163cf150217d1849f57d58f742bbaf624a0699caf0e9d9d7d5fb936726b7f6L30-R30): Added the `required: true` attribute to the client selection field to ensure that users must select a client when creating a new invitation.