### PR TITLE
Fix search pagination

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,20 +3,23 @@ class UsersController < ApplicationController
   before_action :set_user, only: %i[edit update]
 
   def index
-    @users = User.all
-    @users = if params[:query].present?
-               @users.left_joins(:client, :roles)
-                 .where('users.email ILIKE :query OR users.first_name ILIKE :query OR users.last_name ILIKE :query OR
-                  clients.name ILIKE :query OR roles.name ILIKE :query',
-                        query: "%#{params[:query]}%")
-             else
-               @users.order('created_at DESC')
-             end
-    # Pagination for users
-    @per_page = 10
+    @per_page = 3
     @page = (params[:page] || 1).to_i
-    @total_pages = (@users.count / @per_page.to_f).ceil
-    @users = @users.offset((@page - 1) * @per_page).limit(@per_page)
+
+    if params[:query].present?
+      @searched_users = User.left_joins(:client, :roles)
+                            .where('users.email ILIKE :query OR users.first_name ILIKE :query OR
+                            users.last_name ILIKE :query OR clients.name ILIKE :query OR roles.name ILIKE :query',
+                                   query: "%#{params[:query]}%")
+      @total_searched_pages = (@searched_users.count / @per_page.to_f).ceil
+      @searched_users = @searched_users.offset((@page - 1) * @per_page).limit(@per_page)
+      @users = @searched_users
+      @total_pages = @total_searched_pages
+    else
+      @users = User.order('created_at DESC')
+      @total_pages = (@users.count / @per_page.to_f).ceil
+      @users = @users.offset((@page - 1) * @per_page).limit(@per_page)
+    end
   end
 
   def edit; end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,9 @@ class UsersController < ApplicationController
 
     if params[:query].present?
       @searched_users = User.left_joins(:client, :roles)
-                            .where('users.email ILIKE :query OR users.first_name ILIKE :query OR
+        .where('users.email ILIKE :query OR users.first_name ILIKE :query OR
                             users.last_name ILIKE :query OR clients.name ILIKE :query OR roles.name ILIKE :query',
-                                   query: "%#{params[:query]}%")
+               query: "%#{params[:query]}%")
       @total_searched_pages = (@searched_users.count / @per_page.to_f).ceil
       @searched_users = @searched_users.offset((@page - 1) * @per_page).limit(@per_page)
       @users = @searched_users


### PR DESCRIPTION
This pull request includes changes to the `UsersController` to improve the user listing and search functionality by adding pagination for search results and modifying the pagination logic. The most important changes include updating the `index` action to paginate search results and adjusting the default pagination settings.

Improvements to user listing and search functionality:

* [`app/controllers/users_controller.rb`](diffhunk://#diff-cfdccd0a9d5df5a43aaad2a35d36ebbe187c52ad5fdc9846fa189d04537adb6eL6-R23): Added pagination for search results by introducing `@searched_users`, `@total_searched_pages`, and modifying the query logic to include pagination parameters.
* [`app/controllers/users_controller.rb`](diffhunk://#diff-cfdccd0a9d5df5a43aaad2a35d36ebbe187c52ad5fdc9846fa189d04537adb6eL6-R23): Adjusted default pagination settings by changing `@per_page` to 3 and ensuring pagination is applied consistently whether a search query is present or not.