### PR TITLE
Changing project-order

### DIFF
--- a/app/controllers/project_controller.rb
+++ b/app/controllers/project_controller.rb
@@ -7,7 +7,7 @@ class ProjectController < ApplicationController
     @project = if params[:query].present?
                  Project.where('title ILIKE ? OR description ILIKE ?', "%#{params[:query]}%", "%#{params[:query]}%")
                else
-                 Project.all.with_rich_text_content.order('created_at DESC')
+                 Project.all.with_rich_text_content.order('created_at ASC')
                end
 
     @project = @project.joins(:users).where(users: { id: current_user.id }) unless current_user.has_role?(:admin) or current_user.has_role?(:observer)


### PR DESCRIPTION
This pull request includes a small but important change to the `index` method in the `ProjectController`. The change modifies the order in which projects are displayed when no query is provided.

* [`app/controllers/project_controller.rb`](diffhunk://#diff-6144fd8daa15a8e75b5c187fdce2ebfebf35c4dd975fa9888f8f31fe89e0755fL10-R10): Changed the order of projects from descending to ascending based on their creation date when no query is present.