### PR TITLE
Adding bugfix/projects-core-functionality clean up

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -242,10 +242,12 @@ class Ticket < ApplicationRecord
                else
                  'DEFAULT' # Fallback initials
                end
+
     last_ticket = Ticket
+      .where(project_id: project.id)
       .where("unique_id ~ '^[^-]+-\\d+$'") # Only process valid formats
       .order(Arel.sql("CAST(SPLIT_PART(unique_id, '-', 2) AS INTEGER) DESC"))
-      .first || Ticket.order(:created_at).last
+      .first || Ticket.where(project_id: project.id).order(:created_at).last
 
     next_number = if last_ticket&.unique_id.present?
                     last_ticket.unique_id.split('-').last.to_i + 1


### PR DESCRIPTION
This pull request includes a change to the `ticket_unique_id` method in the `app/models/ticket.rb` file to ensure that the ticket ID generation is scoped to the project.

Most important change:

* [`app/models/ticket.rb`](diffhunk://#diff-103c7663225274279e2e159e0eec7a4fcaf32545109353486b5a95a18f3d3adaR245-R250): Modified the `ticket_unique_id` method to scope the ticket ID generation to the project by adding a filter on `project_id` when querying for the last ticket.