### PR TITLE
Allowed agenst to view all service desks until 31st january 2025

### DIFF
--- a/app/controllers/project_controller.rb
+++ b/app/controllers/project_controller.rb
@@ -10,7 +10,7 @@ class ProjectController < ApplicationController
                  Project.all.with_rich_text_content.order('created_at ASC')
                end
 
-    @project = @project.joins(:users).where(users: { id: current_user.id }) unless current_user.has_any_role?(:admin, :observer)
+    @project = @project.joins(:users).where(users: { id: current_user.id }) unless current_user.has_any_role?(:admin, :observer, :agent)
 
     @per_page = 10
     @page = (params[:page] || 1).to_i
@@ -20,7 +20,7 @@ class ProjectController < ApplicationController
 
   # GET /projects/id
   def show
-    if current_user.has_role?(:admin) or @project.users.include?(current_user) or current_user.has_role?(:observer)
+    if current_user.has_role?(:admin) or @project.users.include?(current_user) or current_user.has_role?(:observer) or current_user.has_role?(:agent)
       @ticket = if params[:query].present?
                   @project.tickets.left_joins(:rich_text_content, :statuses)
                     .where('action_text_rich_texts.body ILIKE ? OR issue ILIKE ? OR priority ILIKE ? OR statuses.name ILIKE ? OR unique_id ILIKE ?',

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -32,7 +32,7 @@ class Ability
       cannot %i[create delete edit], Board
       cannot :manage, Task
     elsif user.has_role? :agent
-      can :read, Project
+      can %i[read assign_user unassign_user], Project
       can %i[create read assign_tag unassign_tag update_status add_status], Ticket
       can %i[edit destroy update], Ticket, user_id: user.id
       can :manage, Issue, user_id: user.id

--- a/app/views/project/_add_assign.html.erb
+++ b/app/views/project/_add_assign.html.erb
@@ -1,5 +1,5 @@
 <!-- app/views/project/_add_assign.html.erb -->
-<% if current_user.has_role? :admin or current_user.has_role?('project manager') %>
+<% if current_user.has_role? :admin or current_user.has_role? :agent or current_user.has_role?('project manager') %>
   <div class="grid grid-cols-2 mt-2 gap-2">
     <div class="col-span-1 text-xs">
       <%= form_with url: assign_user_project_path(@project), local: true do %>

--- a/app/views/project/_project_table.html.erb
+++ b/app/views/project/_project_table.html.erb
@@ -21,7 +21,7 @@
     </thead>
     <tbody>
       <% @project.each do |project| %>  <!-- Looping through each project -->
-        <% if project.assigned_to?(current_user) || current_user.has_role?(:admin) or current_user.has_role?(:observer) %>
+        <% if project.assigned_to?(current_user) || current_user.has_role?(:admin) or current_user.has_role?(:observer) or current_user.has_role?(:agent)  %>
 
             <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 h-12 text-center">
               <td class="px-6 py-4 font-medium text-left">


### PR DESCRIPTION
This pull request introduces several changes to extend the permissions and visibility for users with the `:agent` role across the project management application. The most important changes include modifications to the `project_controller`, `ability` model, and various view files to incorporate the `:agent` role alongside existing roles.

Changes to permissions and visibility for `:agent` role:

* [`app/controllers/project_controller.rb`](diffhunk://#diff-6144fd8daa15a8e75b5c187fdce2ebfebf35c4dd975fa9888f8f31fe89e0755fL13-R13): Updated the `index` and `show` actions to include the `:agent` role in the permission checks. [[1]](diffhunk://#diff-6144fd8daa15a8e75b5c187fdce2ebfebf35c4dd975fa9888f8f31fe89e0755fL13-R13) [[2]](diffhunk://#diff-6144fd8daa15a8e75b5c187fdce2ebfebf35c4dd975fa9888f8f31fe89e0755fL23-R23)
* [`app/models/ability.rb`](diffhunk://#diff-0fdc2ce2595c4fe479d6a97b404013651e8a0e2d4b02d93c87843b3a30103d9fL35-R35): Enhanced the `:agent` role capabilities to include `assign_user` and `unassign_user` actions on `Project`.

Updates to view files for `:agent` role:

* [`app/views/project/_add_assign.html.erb`](diffhunk://#diff-7beb150af06b45c1a128a31d8147fcaacaad9c668acf798ce7ac046a4edc887cL2-R2): Modified the condition to display the assignment form to include users with the `:agent` role.
* [`app/views/project/_project_table.html.erb`](diffhunk://#diff-a28008a863a12520a57aad9e8eab7a3d1dc3da4b613e186621075da2b9289667L24-R24): Adjusted the visibility condition for project rows to include users with the `:agent` role.