### PR TITLE
Remove emails from system

### DIFF
--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -87,11 +87,11 @@ class ProductController < ApplicationController
 
       assigned_user = user
       UserMailer.assign_product_email(@product.user, @product, current_user, assigned_user).deliver_later
-      @product.users.each do |product_user|
-        next if product_user == current_user
+      # @product.users.each do |product_user|
+      #  next if product_user == current_user
 
-        UserMailer.assign_product_email(product_user, @product, current_user, assigned_user).deliver_later
-      end
+      # UserMailer.assign_product_email(product_user, @product, current_user, assigned_user).deliver_later
+      # end
 
       redirect_to @product, notice: 'User was successfully assigned.'
     end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -63,11 +63,11 @@ class TasksController < ApplicationController
       # Send email to the newly assigned user
       UserMailer.task_assignment_email(user, @task, current_user, assigned_user).deliver_later
       # Send email to all users tagged on the product, except the current user
-      @product.users.each do |product_user|
-        next if product_user == current_user
+      # @product.users.each do |product_user|
+      #   next if product_user == current_user
 
-        UserMailer.task_assignment_email(product_user, @task, current_user, assigned_user).deliver_later
-      end
+      #   UserMailer.task_assignment_email(product_user, @task, current_user, assigned_user).deliver_later
+      # end
 
       redirect_to product_board_task_path(@product, @board, @task), notice: 'Task was successfully assigned.'
     end
@@ -90,11 +90,11 @@ class TasksController < ApplicationController
     @task.save
 
     UserMailer.add_state_email(@task.user, @task, current_user).deliver_later
-    @product.users.each do |product_user|
-      next if product_user == current_user
+    # @product.users.each do |product_user|
+    #   next if product_user == current_user
 
-      UserMailer.add_state_email(product_user, @task, current_user).deliver_later
-    end
+    #   UserMailer.add_state_email(product_user, @task, current_user).deliver_later
+    # end
     redirect_to product_path(@product)
   end
 


### PR DESCRIPTION
This pull request includes changes to the email notification logic in the `product_controller` and `tasks_controller` by commenting out the code that sends emails to all product users except the current user. The most important changes are:

Email notification logic adjustments:

* [`app/controllers/product_controller.rb`](diffhunk://#diff-fb6d52c8e1f572d48fbc714f60fe113386ded18750f81b19ca971fbb4a4d9996L90-R94): Commented out the code that sends an email to all product users except the current user when a user is assigned to a product.
* [`app/controllers/tasks_controller.rb`](diffhunk://#diff-de1aaaf7a00c963e6a5e77045d8cbdafa5ebc81e1250a7ea1862a51d824e9945L66-R70): Commented out the code that sends an email to all product users except the current user when a task is assigned.
* [`app/controllers/tasks_controller.rb`](diffhunk://#diff-de1aaaf7a00c963e6a5e77045d8cbdafa5ebc81e1250a7ea1862a51d824e9945L93-R97): Commented out the code that sends an email to all product users except the current user when a state is added to a task.