### PR TITLE
Adding bugfix/projects-core-functionality clean up

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Metrics/ClassLength:
   Max: 210
 Metrics/BlockLength:
   AllowedMethods: ['describe']
-  Max: 30
+  Max: 40
 Metrics/CyclomaticComplexity:
   Max: 25
 Metrics/PerceivedComplexity:

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -193,13 +193,16 @@ class TicketsController < ApplicationController
       )
 
       # Adding the SLA to the ticket
-      SlaTicket.find_or_create_by!(ticket_id: @ticket.id) do |sla_ticket|
+      sla_ticket = SlaTicket.find_or_create_by!(ticket_id: @ticket.id) do |sla_ticket|
         sla_ticket.sla_status = @ticket.sla_status
       end
 
+      # Log the details of the SlaTicket including the SLA status
+      Rails.logger.info("SlaTicket details: #{sla_ticket.attributes}, SLA Status: #{sla_ticket.sla_status}")
+
       UserMailer.ticket_assignment_email(user, @ticket, current_user, assigned_user).deliver_later
 
-      log_event(@ticket, current_user, 'assign', "#{user.name} was assigned to the ticket.")
+      log_event(@ticket, current_user, 'assign', "#{user.name} was assigned to the ticket, with Status: #{sla_ticket.sla_status}")
 
       redirect_to project_ticket_path(@project, @ticket), notice: 'Ticket was successfully assigned.'
     end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -92,15 +92,20 @@ class TicketsController < ApplicationController
       if @ticket.errors.any? || !@ticket.save
         format.html { render :new, status: :unprocessable_entity }
       else
-
         if @ticket.groupware_id.present?
           groupware = Groupware.find(@ticket.groupware_id)
           tagged_user = groupware.user
-          # Assign the tagged user if present
-          @ticket.users << tagged_user if tagged_user.present?
+          # Assign the tagged user if present and part of the project
+          @ticket.users << if tagged_user.present? && @project.users.include?(tagged_user)
+                             tagged_user
+                           else
+                             # Assign the default user if tagged user is not part of the project
+                             @project.user
+                           end
+        elsif @ticket.users.empty?
+          @ticket.users << @project.user
         end
         # Assign the project manager if no agents are assigned
-        @ticket.users << @project.user if @ticket.users.empty?
 
         # Assign status to new ticket
         status = Status.find_by(name: 'New')

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -193,8 +193,8 @@ class TicketsController < ApplicationController
       )
 
       # Adding the SLA to the ticket
-      sla_ticket = SlaTicket.find_or_create_by!(ticket_id: @ticket.id) do |sla_ticket|
-        sla_ticket.sla_status = @ticket.sla_status
+      sla_ticket = SlaTicket.find_or_create_by!(ticket_id: @ticket.id) do |sla|
+        sla.sla_status = @ticket.sla_status
       end
 
       # Log the details of the SlaTicket including the SLA status


### PR DESCRIPTION
This pull request includes changes to the `.rubocop.yml` configuration and the `create` method in the `tickets_controller.rb` file. The most important changes are increasing the maximum block length allowed in RuboCop and improving the logic for assigning users to a ticket based on their association with the project.

### Configuration Changes:
* [`.rubocop.yml`](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cL29-R29): Increased the maximum allowed block length from 30 to 40.

### Code Improvements:
* [`app/controllers/tickets_controller.rb`](diffhunk://#diff-d4c5ab3656241a42b628137d4f0e84e6fbaa7bb928bc4569b9cfe442a583ffcdL95-L103): Enhanced the user assignment logic in the `create` method to ensure that the tagged user is part of the project, and if not, assigns the default project user. Additionally, assigns the project user if no users are assigned to the ticket.