### PR TITLE
Adding number of users seen on the client

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -5,4 +5,8 @@ class Client < ApplicationRecord
   # has_many :data_centers, dependent: :nullify
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 50 }
+
+  def users_count
+    User.where(client_id: id).count
+  end
 end

--- a/app/views/client/_client.html.erb
+++ b/app/views/client/_client.html.erb
@@ -7,14 +7,14 @@
         Name of the Client
       </th>
       <th scope="col" class="px-6 py-3">
+        No of Users Per Client
+      </th>
+      <th scope="col" class="px-6 py-3">
         Email Address
       </th>
 
       <th scope="col" class="px-6 py-3">
         Phone Number
-      </th>
-      <th scope="col" class="px-6 py-3">
-        Address
       </th>
       <th scope="col" class="px-6 py-3">
         Name of The Contact Person
@@ -43,6 +43,9 @@
         <th scope="row" class="px-6 py-4 font-medium  whitespace-nowrap ">
           <%= client.name   %>
         </th>
+        <td class="px-6 py-4 truncate w-64">
+          <%= client.users_count %>
+        </td>
 
         <td class="px-6 py-4 truncate w-64">
           <%= client.email %>
@@ -50,9 +53,6 @@
 
         <td class="px-6 py-4 truncate w-64">
           <%= client.phone %>
-        </td>
-        <td class="px-6 py-4 truncate w-64">
-          <%= client.address %>
         </td>
         <td class="px-6 py-4 truncate w-64">
           <%= client.client_contact_person %>


### PR DESCRIPTION
This pull request introduces a new feature to display the number of users per client in the client view. The changes involve adding a method to the `Client` model and updating the client view to include the new information.

Key changes:

* **Model Update:**
  * [`app/models/client.rb`](diffhunk://#diff-4ec829f3dadc01ce07332ae63c8a85a74fa6d01c2ca27118db63b2dffde41ea2R8-R11): Added a `users_count` method to the `Client` model to count the number of users associated with each client.

* **View Update:**
  * [`app/views/client/_client.html.erb`](diffhunk://#diff-fa07faf2ba1267d0cad8bdf555b05dc589c53cc8055a0c04de059ecd9a0a9369R9-L18): Added a new column header for "No of Users Per Client" and removed the "Address" column header.
  * [`app/views/client/_client.html.erb`](diffhunk://#diff-fa07faf2ba1267d0cad8bdf555b05dc589c53cc8055a0c04de059ecd9a0a9369R46-R48): Added a new table cell to display the user count for each client and removed the table cell for the address. [[1]](diffhunk://#diff-fa07faf2ba1267d0cad8bdf555b05dc589c53cc8055a0c04de059ecd9a0a9369R46-R48) [[2]](diffhunk://#diff-fa07faf2ba1267d0cad8bdf555b05dc589c53cc8055a0c04de059ecd9a0a9369L54-L56)