### PR TITLE
Timeout nil

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -9,4 +9,8 @@ class Client < ApplicationRecord
   def users_count
     User.where(client_id: id).count
   end
+
+  def projects_count
+    Project.where(client_id: id).count
+  end
 end

--- a/app/views/client/_client.html.erb
+++ b/app/views/client/_client.html.erb
@@ -10,6 +10,9 @@
         No of Users Per Client
       </th>
       <th scope="col" class="px-6 py-3">
+        No of Projects Per Client
+      </th>
+      <th scope="col" class="px-6 py-3">
         Email Address
       </th>
 
@@ -45,6 +48,9 @@
         </th>
         <td class="px-6 py-4 truncate w-64">
           <%= client.users_count %>
+        </td>
+        <td class="px-6 py-4 truncate w-64">
+          <%= client.projects_count %>
         </td>
 
         <td class="px-6 py-4 truncate w-64">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -237,7 +237,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 8.hours
+  config.timeout_in = nil
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
This pull request includes changes to the `Client` model, the client view, and the Devise configuration. The main updates are the addition of a method to count projects per client and the modification of the session timeout configuration.

### Enhancements to Client Model and View:

* [`app/models/client.rb`](diffhunk://#diff-4ec829f3dadc01ce07332ae63c8a85a74fa6d01c2ca27118db63b2dffde41ea2R12-R15): Added `projects_count` method to count the number of projects associated with a client.
* [`app/views/client/_client.html.erb`](diffhunk://#diff-fa07faf2ba1267d0cad8bdf555b05dc589c53cc8055a0c04de059ecd9a0a9369R12-R14): Added a new column to display the number of projects per client. [[1]](diffhunk://#diff-fa07faf2ba1267d0cad8bdf555b05dc589c53cc8055a0c04de059ecd9a0a9369R12-R14) [[2]](diffhunk://#diff-fa07faf2ba1267d0cad8bdf555b05dc589c53cc8055a0c04de059ecd9a0a9369R52-R54)

### Configuration Changes:

* [`config/initializers/devise.rb`](diffhunk://#diff-cb6e8126296dbc007e7625eee863de5c3213ed949b9999ea3418775f65826531L240-R240): Set `config.timeout_in` to `nil` to disable session timeout.