### PR TITLE
Adding number of users seen on the client

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -30,7 +30,11 @@ class Project < ApplicationRecord
   end
 
   def users_with_same_client
-    User.where('(client_id = ? OR email LIKE ?) AND active = ?', client_id, '%@craftsilicon.com', true)
+    User.where(client_id: client_id, active: true)
+  end
+
+  def craftsilicon_users
+    User.where('email LIKE ? AND active = ?', '%@craftsilicon.com', true)
   end
 
   # To have pick a list of users who have role agent only on a dropdown list at the view to assign a project

--- a/app/views/project/_add_assign.html.erb
+++ b/app/views/project/_add_assign.html.erb
@@ -1,13 +1,33 @@
 <!-- app/views/project/_add_assign.html.erb -->
 <% if current_user.has_role? :admin or current_user.has_role?('project manager') %>
-  <div class="grid grid-cols-2 mt-2 gap-2">
+  <div class="grid grid-cols-3 mt-2 gap-2">
     <div class="col-span-1 text-xs">
       <%= form_with url: assign_user_project_path(@project), local: true do %>
-        <%= label_tag :user_id, "SELECT USER" %>
+        <%= label_tag :user_id, "Clients" %>
         <div class="flex flex-wrap gap-2">
           <div>
             <%= select_tag :user_id, options_from_collection_for_select(
               @project.users_with_same_client
+                      .where.not(id: @project.users.pluck(:id))
+                      .distinct,
+              :id, :name),
+                           class: "h-12 max-w-[120px] border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg mr-1",
+                           required: true
+            %>
+          </div>
+          <div class=" col-span-1">
+            <%= submit_tag "ADD USER", class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <div class="col-span-1 text-xs">
+      <%= form_with url: assign_user_project_path(@project), local: true do %>
+        <%= label_tag :user_id, "Craft silicon users" %>
+        <div class="flex flex-wrap gap-2">
+          <div>
+            <%= select_tag :user_id, options_from_collection_for_select(
+              @project.craftsilicon_users
                       .where.not(id: @project.users.pluck(:id))
                       .distinct,
               :id, :name),


### PR DESCRIPTION
This pull request includes changes to the `Project` model and the `_add_assign` view to improve user assignment functionality. The main changes involve separating the selection of users by clients and craft silicon users, and updating the view to accommodate these changes.

Changes to the `Project` model:

* [`app/models/project.rb`](diffhunk://#diff-611e7045e8b0212d101cd856c335296959519af63b80129f51c246a7bbfe7b91L33-R37): Split the `users_with_same_client` method into two separate methods: `users_with_same_client` and `craftsilicon_users`. This change improves clarity and separation of concerns.

Changes to the `_add_assign` view:

* [`app/views/project/_add_assign.html.erb`](diffhunk://#diff-7beb150af06b45c1a128a31d8147fcaacaad9c668acf798ce7ac046a4edc887cL3-R6): Updated the grid layout to accommodate an additional column for craft silicon users.
* [`app/views/project/_add_assign.html.erb`](diffhunk://#diff-7beb150af06b45c1a128a31d8147fcaacaad9c668acf798ce7ac046a4edc887cR24-R43): Added a new form section for assigning craft silicon users to the project. This includes a new select tag for `craftsilicon_users` and a submit button to add the user.