### PR TITLE
Changing the size of the content

### DIFF
--- a/app/javascript/controllers/text_limit_controller.js
+++ b/app/javascript/controllers/text_limit_controller.js
@@ -3,10 +3,10 @@ import { Controller } from '@hotwired/stimulus';
 export default class extends Controller {
   static targets = ['content']
 
-  static values = { limit: { type: Number, default: 1200 } }
+  static values = { limit: { type: Number, default: 3000 } }
 
   connect() {
-    this.limitValue = Math.min(this.limitValue, 1200); // Ensure limit does not exceed 1200
+    this.limitValue = Math.min(this.limitValue, 3000); // Ensure limit does not exceed 1200
     this.updateCounter();
     this.contentTarget.addEventListener('input', (event) => this.enforceLimit(event));
   }

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -267,7 +267,7 @@ class Ticket < ApplicationRecord
   end
 
   def content_length_within_limit
-    return unless content.to_plain_text.length > 1200
+    return unless content.to_plain_text.length > 3000
 
     errors.add(:content, 'must be less than or equal to 1200 characters')
   end

--- a/app/views/tickets/_edit_form.html.erb
+++ b/app/views/tickets/_edit_form.html.erb
@@ -76,7 +76,7 @@
     <div class="relative z-0 w-full mb-6 group">
       <%= f.label :title, ('Subject *'), class: "capitalize block mb-1 text-sm font-medium"  %><br />
       <div data-controller="text-limit" data-text-limit-limit-value="1200">
-        <p id="char-count">0/1200</p>
+        <p id="char-count">0/3000</p>
         <%= f.rich_text_area :content, id: "content", data: { text_limit_target: "content", is_admin: current_user.has_role?(:admin) || current_user.has_role?('project manager') || current_user.has_role?('agent') }, class: "min-h-[300px] #{'border-red-500' if @ticket.errors[:content].any?}" %>
       </div>
     </div>

--- a/app/views/tickets/_form.html.erb
+++ b/app/views/tickets/_form.html.erb
@@ -77,7 +77,7 @@
       <%= f.label :title, ('Description *'), class: "capitalize block mb-1 text-sm font-medium"  %>
       <br />
       <div data-controller="text-limit" data-text-limit-limit-value="1200">
-        <p id="char-count">0/1200</p>
+        <p id="char-count">0/3000</p>
         <%= f.rich_text_area :content, id: "content", data: { text_limit_target: "content", is_admin: current_user.has_role?(:admin) || current_user.has_role?('project manager') || current_user.has_role?('agent') }, class: "min-h-[300px] #{'border-red-500' if @ticket.errors[:content].any?}" %>      </div>
       <!-- Attachments -->
       <% if @ticket.attachments.any? %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -49,8 +49,8 @@
           <%= @ticket.subject %>
          </span>
         </div>
-        <div class="mb-2.5 font-bold capitalize">Content:
-          <span class="font-extralight">
+        <div class="mb-2.5 font-bold capitalize ">Content:
+          <span class="font-extralight p-2">
             <%= @ticket.content.to_plain_text.truncate(1600) %>
           </span>
         </div>


### PR DESCRIPTION
This pull request includes changes to increase the content limit for tickets from 1200 to 3000 characters. The most important changes are as follows:

### Content limit increase:

* [`app/javascript/controllers/text_limit_controller.js`](diffhunk://#diff-6d212eafed2aab548d70bed17d4011468b401b59beafd7b9108d23322556f04aL6-R9): Updated the `limit` value from 1200 to 3000 and adjusted the `connect` method to ensure the new limit is enforced.
* [`app/models/ticket.rb`](diffhunk://#diff-103c7663225274279e2e159e0eec7a4fcaf32545109353486b5a95a18f3d3adaL270-R270): Modified the `content_length_within_limit` method to check for the new limit of 3000 characters instead of 1200.

### View updates:

* [`app/views/tickets/_edit_form.html.erb`](diffhunk://#diff-3efcd6cf5a4b91f4e8a9f1dc42dbbe3859e9c90297d090b9e769adad1a06ec25L79-R79): Updated the character count display from 1200 to 3000 in the edit form.
* [`app/views/tickets/_form.html.erb`](diffhunk://#diff-0c8e6f1d2ab8cb8ba63fa746c934146339564bb03ab4480c50b87af1a8e1f3f7L80-R80): Updated the character count display from 1200 to 3000 in the form.

### Content display adjustment:

* [`app/views/tickets/show.html.erb`](diffhunk://#diff-99e200cfd1003b33f0a45daca511786346c2f5d376596d8c5aabdaf18052cc2dL53-R53): Added padding to the content display span for better visual presentation.