### PR TITLE
Views on tickets to select

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,49 @@
 <div class="p-4 border-2 border-white rounded-lg flex flex-col items-center">
+
+<!-- Topbar Section  for admin and observer-->
+  <% if current_user.has_role?(:admin) or current_user.has_role?(:observer) %>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2 mb-6 w-full ">
+    <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
+      <p class="text-xs sm:text-sm truncate">
+        All Service Desks
+      </p>
+      <span class="text-lg sm:text-xl font-bold">
+        <%= current_user.projects.distinct.count %>
+      </span>
+    </div>
+    <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
+      <p class="text-xs sm:text-sm truncate">
+        All Open Tickets
+      </p>
+      <span class="text-lg sm:text-xl font-bold">
+        <%= Ticket.joins(:statuses).where.not(statuses: { name: %w[Closed Resolved] }).distinct.count %>      </span>
+    </div>
+    <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
+      <p class="text-xs sm:text-sm truncate">
+        All Tickets
+      </p>
+      <span class="text-lg sm:text-xl font-bold">
+        <%= Ticket.joins(:statuses, :project).where(projects: { id: current_user.projects.ids }).where.not(statuses: { name: %w[Closed Resolved] }).distinct.count %>
+      </span>
+    </div>
+    <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
+      <p class="text-xs sm:text-sm truncate">
+        Active Clients(Clients who have login more than once)
+      </p>
+      <span class="text-lg sm:text-xl font-bold">
+        <%= User.joins(:roles).where(roles: { name: 'client' }).where('sign_in_count > ?', 0).count %>      </span>
+    </div>
+    <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
+      <p class="text-xs sm:text-sm truncate">
+        Tickets Closed in the last one week
+      </p>
+      <span class="text-lg sm:text-xl font-bold">
+        <%= Ticket.joins(:statuses).where(statuses: { name: %w[Closed Resolved] }).where('tickets.updated_at >= ?', 1.week.ago).count %>
+      </span>
+    </div>
+  </div>
+    <% end %>
+
   <!-- First Grid Section -->
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2 mb-4 w-full">
     <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
@@ -27,6 +72,7 @@
 
     </div>
   </div>
+
 
   <!-- Table Section -->
   <div class="flex flex-wrap items-center mb-4 rounded bg-gray-50 dark:bg-gray-800 p-2 sm:p-4 w-full">


### PR DESCRIPTION
This pull request introduces a new topbar section for admin and observer roles in the `app/views/home/index.html.erb` file. The topbar displays various metrics related to service desks, tickets, and active clients.

Key changes include:

* **New Topbar Section for Admin and Observer Roles:**
  * Added a conditional block to check if the current user has an admin or observer role.
  * Included metrics such as the count of all service desks, all open tickets, all tickets, active clients, and tickets closed in the last week.

* **Minor Formatting Adjustments:**
  * Added spacing and alignment adjustments to the existing grid and table sections for better visual consistency.