### PR TITLE
Revert "Views on tickets to select"

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -12,7 +12,7 @@ class Ticket < ApplicationRecord
   has_many :ratings, dependent: :destroy
   validates :image, content_type: %w[image/png image/jpeg], size: { less_than: 5.megabytes }
   has_many :events, dependent: :destroy
-  validates :unique_id, uniqueness: true
+
   before_update :track_updates
   before_create :set_default_status
 

--- a/app/views/bugs/_status_bug.html.erb
+++ b/app/views/bugs/_status_bug.html.erb
@@ -14,10 +14,41 @@
   </p>
 <% end %>
 
+
 <% if current_user.has_role? :admin or current_user.has_role? :agent or  current_user.has_role?('project manager') %>
   <%= form_with url: bug_status_product_bug_path(@product, @bug), local: true do %>
-
-      <%= select_tag :status_id, options_for_select(Status.where(name: ['TO DO','Awaiting Build','Awaiting Client Information','Blocked','Failed QA', 'In Progress','On-Hold', 'QA Testing', 'Reopened','Support Testing' ]).collect { |status| [status.name, status.id] }, @bug.statuses.first&.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+    <% if @bug.statuses.empty? %>
+      <%= select_tag :status_id, options_for_select(Status.where(name: %w[Assigned]).collect { |status| [status.name, status.id] }, @bug.statuses.first&.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+    <% else %>
+      <% @bug.statuses.each do |status| %>
+        <% case status.name %>
+<% when 'New' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: %w[Assigned]).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'Assigned' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: ['Work in Progress']).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'Work in Progress' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: ['Declined', 'Resolved', 'On-Hold', 'Under Development', 'Client Confirmation Pending']).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'On-Hold' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: ['Under Development', 'Work in Progress']).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'Under Development' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: ['QA Testing', 'Awaiting Build', 'On-Hold']).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'QA Testing' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: ['Resolved', 'Client Confirmation Pending', 'Under Development']).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'Client Confirmation Pending' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: ['Resolved', 'Reopened', 'Work in Progress']).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'Awaiting Build' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: ['QA Testing']).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'QA Testing' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: ['Resolved', 'Client Confirmation Pending']).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'Reopened' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: ['Work in Progress']).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'Closed', 'Declined' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: ['Reopened']).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% when 'Resolved' %>
+          <%= select_tag :status_id, options_for_select(Status.where(name: %w[Closed Reopened]).collect { |status| [status.name, status.id] }, @bug.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+        <% end %>
+      <% end %>
+    <% end %>
     <%= submit_tag "UPDATE STATUS", class: 'w-full font-semibold bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100 mt-2' %>
   <% end %>
 

--- a/app/views/home/_table_ticket_per_project.html.erb
+++ b/app/views/home/_table_ticket_per_project.html.erb
@@ -2,32 +2,32 @@
   <div class="overflow-x-auto w-full">
     <table class="min-w-full w-full text-xs sm:text-sm text-center text-gray-500 dark:text-gray-400">
       <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
-      <tr>
-        <th scope="col" class="px-4 sm:px-6 py-2 sm:py-3 text-left whitespace-nowrap">
-          Name of The Project
-        </th>
-        <th scope="col" class="px-4 sm:px-6 py-2 sm:py-3 text-left whitespace-nowrap">
-          Total Number of Tickets
-        </th>
-        <th scope="col" class="px-4 sm:px-6 py-2 sm:py-3 text-left whitespace-nowrap">
-          Ticket Number
-        </th>
-      </tr>
+        <tr>
+          <th scope="col" class="px-4 sm:px-6 py-2 sm:py-3 text-left whitespace-nowrap">
+            Name of The Project
+          </th>
+          <th scope="col" class="px-4 sm:px-6 py-2 sm:py-3 text-left whitespace-nowrap">
+            Total Number of Tickets
+          </th>
+          <th scope="col" class="px-4 sm:px-6 py-2 sm:py-3 text-left whitespace-nowrap">
+            Ticket Number
+          </th>
+        </tr>
       </thead>
       <tbody>
-      <% @issues_count_per_project_for_current_user.each do |project_title, issue_count| %>
-        <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 text-center">
-          <th scope="row" class="text-left capitalize px-4 sm:px-6 py-2 sm:py-4 font-medium whitespace-nowrap">
-            <%= link_to project_title, project_path(Project.find_by(title: project_title)) %>
-          </th>
-          <td class="px-4 sm:px-6 py-2 sm:py-4">
-            <%= @tickets_count_per_project[project_title] %>
-          </td>
-          <td class="px-4 sm:px-6 py-2 sm:py-4">
-            <%= issue_count %>
-          </td>
-        </tr>
-      <% end %>
+        <% @issues_count_per_project_for_current_user.each do |project_title, issue_count| %>
+          <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 text-center">
+            <th scope="row" class="text-left capitalize px-4 sm:px-6 py-2 sm:py-4 font-medium whitespace-nowrap">
+              <%= project_title %>
+            </th>
+            <td class="px-4 sm:px-6 py-2 sm:py-4">
+              <%= @tickets_count_per_project[project_title] %>
+            </td>
+            <td class="px-4 sm:px-6 py-2 sm:py-4">
+              <%= issue_count %>
+            </td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
   <%= javascript_importmap_tags %>
   <%= Sentry.get_trace_propagation_meta.html_safe %>
   <%= javascript_include_tag "controllers/tribute_controller", defer: true %>
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.25/css/jquery.dataTables.min.css">
   <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
   <script src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.min.js"></script>
   <link


### PR DESCRIPTION
Reverts ger619/CSPM#549
This pull request includes several changes to the project, focusing on improving the bug status selection, removing a uniqueness validation, and updating the project title display. The most important changes include modifying the bug status form, removing a uniqueness validation, and updating the ticket table.

Bug status selection improvements:

* [`app/views/bugs/_status_bug.html.erb`](diffhunk://#diff-e8f170f0a0436b75403a037ee545422a619510c3a77caebefe77872cb79fb943R17-R51): Enhanced the bug status selection logic to dynamically display different status options based on the current status of the bug. This change ensures that users see relevant status options depending on the current bug status.

Validation updates:

* [`app/models/ticket.rb`](diffhunk://#diff-103c7663225274279e2e159e0eec7a4fcaf32545109353486b5a95a18f3d3adaL15-R15): Removed the uniqueness validation for the `unique_id` attribute. This change simplifies the model and may be due to a shift in how uniqueness is handled or validated elsewhere in the application.

Project title display:

* [`app/views/home/_table_ticket_per_project.html.erb`](diffhunk://#diff-f8af528682f9bf3edf9a6239c3192e2541ecc224b47c1daee2d9f8bb583285b7L21-R21): Changed the project title display to plain text instead of a link. This change likely aims to simplify the UI and reduce unnecessary navigation.

Additional changes:

* [`app/views/layouts/application.html.erb`](diffhunk://#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3ebR16): Added a CSS link for DataTables to enhance table styling and functionality. This change includes the necessary external stylesheet for DataTables integration.