### PR TITLE
CAB Fixed

### DIFF
--- a/app/views/tickets/_ticket_action.html.erb
+++ b/app/views/tickets/_ticket_action.html.erb
@@ -1,5 +1,5 @@
 
-<% if @project.special %>
+<% if @project.special and @ticket.issue == 'CHANGE REQUEST' %>
   <% if current_user.has_role?(:admin) or current_user.has_role?(:observer) %>
   <%= form_with url: add_status_project_ticket_path(@project, @ticket), local: true do %>
     <% if @ticket.statuses.empty? %>


### PR DESCRIPTION
This pull request includes a modification to the ticket action view to ensure that the form is only displayed for special projects when the ticket issue is a "CHANGE REQUEST". 

* [`app/views/tickets/_ticket_action.html.erb`](diffhunk://#diff-3120d1f6b1a72cf48d33466287adea20f17a8beddb8e00ffe764edc1fe0aeb77L2-R2): Updated the condition to check both if the project is special and if the ticket issue is 'CHANGE REQUEST' before displaying the form.