### PR TITLE
Views on tickets to select

### DIFF
--- a/app/views/data_center/orm_report.html.erb
+++ b/app/views/data_center/orm_report.html.erb
@@ -19,9 +19,9 @@
       <div class="flex flex-col gap-2 w-full sm:w-1/6 md:w-1/6">
         <%= f.label :client_id, "Client" %>
         <% if current_user.has_role?(:admin) || current_user.has_role?(:observer) %>
-          <%= f.collection_select :client_id, Client.all, :id, :name, include_blank: true %>
+          <%= f.collection_select :client_id, Client.all, :id, :name, prompt: 'All Clients' %>
         <% else %>
-          <%= f.collection_select :client_id, Client.joins(:projects).where(projects: { id: current_user.projects.ids }).distinct, :id, :name, include_blank: true %>
+          <%= f.collection_select :client_id, Client.joins(:projects).where(projects: { id: current_user.projects.ids }).distinct, :id, :name, prompt: 'All clients' %>
         <% end %>
       </div>
       <div class="flex flex-col gap-2 w-full sm:w-1/6 md:w-1/6 pt-9">
@@ -115,8 +115,8 @@
           <td class="border px-4 py-2"><%= ticket.created_at.strftime("%d-%b-%Y") %></td>
           <td class="capitalize border px-4 py-2"><%= ticket.project.title %></td>
           <td class="border px-4 py-2"><%= ticket.unique_id %></td>
-          <td class="border px-4 py-2"><%= ticket.subject %></td>
           <td class="border px-4 py-2"><%= ticket.issue %></td>
+          <td class="border px-4 py-2"><%= ticket.subject %></td>
           <td class="border px-4 py-2"><%= ticket.statuses.first&.name || 'N/A' %></td>
           <td class="border px-4 py-2"><%= ticket.priority %></td>
           <td class="border px-4 py-2"><%= ticket.users.map(&:name).select(&:present?).join(', ') %></td>


### PR DESCRIPTION
This pull request includes updates to the `app/views/data_center/orm_report.html.erb` file to improve the user interface and fix a minor issue with the display of ticket subjects.

User Interface Improvements:

* Changed the `collection_select` prompt for `client_id` to display 'All Clients' instead of a blank option for both admin/observer users and non-admin users.

Bug Fix:

* Moved the `ticket.subject` column back to its original position to fix a display issue.