### PR TITLE
Statues push

### DIFF
--- a/app/views/data_center/breach_report.html.erb
+++ b/app/views/data_center/breach_report.html.erb
@@ -14,7 +14,7 @@
       <div class="flex flex-col gap-1 w-full sm:w-1/2 lg:w-1/3">
         <%= f.label :status, "Status", class: "capitalize text-xs font-bold" %>
         <%= f.select :status,
-                     options_from_collection_for_select(Status.all, :name, :name, params[:status]),
+                     options_from_collection_for_select(Status.where(name: ['New', 'Closed', 'Resolved', 'Reopened', 'Under Development', 'Work in Progress', 'QA Testing', 'Awaiting Build', 'Client Confirmation Pending', 'On-Hold', 'Assigned', 'Declined']), :name, :name, params[:status]),
                      { include_blank: 'All Statuses' },
                      class: "h-10 border border-gray-300 rounded-lg dark:text-black px-2 text-sm" %>
       </div>

--- a/app/views/data_center/cease_fire_report.html.erb
+++ b/app/views/data_center/cease_fire_report.html.erb
@@ -13,7 +13,7 @@
       <div class="flex flex-col gap-2 w-full sm:w-1/2 md:w-1/3">
         <%= f.label :status, "Status", class: "capitalize text-sm font-bold w-full align-middle pt-3" %>
         <%= f.select :status,
-                     options_from_collection_for_select(Status.all, :name, :name, params[:status]),
+                     options_from_collection_for_select(Status.where(name: ['New', 'Closed', 'Resolved', 'Reopened', 'Under Development', 'Work in Progress', 'QA Testing', 'Awaiting Build', 'Client Confirmation Pending', 'On-Hold', 'Assigned', 'Declined']), :name, :name, params[:status]),
                      { include_blank: 'All Statuses' },
                      class: "h-12 border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full" %>
       </div>


### PR DESCRIPTION
This pull request includes updates to the status selection dropdowns in two HTML files. The changes ensure that only specific statuses are available for selection in the forms.

Changes to status selection:

* [`app/views/data_center/breach_report.html.erb`](diffhunk://#diff-80e8de6bafe696f57d068f1f33b59464e0c12a9501d85a0175ab9b6d681d297eL17-R17): Updated the `status` dropdown to include only specific statuses instead of all statuses.
* [`app/views/data_center/cease_fire_report.html.erb`](diffhunk://#diff-413ef0b0ccf29cf8ad0c2dae1da8e1b6bdfcd6656d3eede0a1db94ee98b1cc5eL16-R16): Updated the `status` dropdown to include only specific statuses instead of all statuses.