### PR TITLE
Add the dynamic way of sla no count

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -49,6 +49,16 @@ class DashboardsController < ApplicationController
         .where(sla_resolution_deadline: 'Not Breached')
         .count
 
+      not_resolution_data_breached_tickets_last_30_days = Ticket
+        .where(software_id: software)
+        .where('created_at >= ?', 30.days.ago)
+        .where.not(id: SlaTicket.where.not(sla_resolution_deadline: nil)
+                                .or(SlaTicket.where.not(sla_target_response_deadline: nil))
+                                .or(SlaTicket.where.not(sla_status: nil))
+                                .select(:ticket_id))
+        .distinct
+        .count
+
       stats = {
         total_tickets_last_30_days: total_tickets_last_30_days,
         breached_tickets_last_30_days: breached_tickets_last_30_days,
@@ -56,7 +66,8 @@ class DashboardsController < ApplicationController
         response_breached_tickets_last_30_days: response_breached_tickets_last_30_days,
         not_response_breached_tickets_last_30_days: not_response_breached_tickets_last_30_days,
         resolution_breached_tickets_last_30_days: resolution_breached_tickets_last_30_days,
-        not_resolution_breached_tickets_last_30_days: not_resolution_breached_tickets_last_30_days
+        not_resolution_breached_tickets_last_30_days: not_resolution_breached_tickets_last_30_days,
+        not_resolution_data_breached_tickets_last_30_days: not_resolution_data_breached_tickets_last_30_days
       }
 
       render json: stats

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -22,7 +22,7 @@
     <%= render 'dashboards/stat_card', title: "Target Repair Time - Not Breached", value: @stats[:not_response_breached_tickets_last_30_days], id: "target_repair_time_not_breached" %>
     <%= render 'dashboards/stat_card', title: "Target Resolution Time - Breached", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached" %>
     <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached" %>
-    <%= render 'dashboards/stat_card', title: "No SLA Count", value: "0", id: "no_sla_count" %>
+    <%= render 'dashboards/stat_card', title: "No SLA Count", value: @stats[:not_resolution_data_breached_tickets_last_30_days], id: "no_sla_count" %>
     <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days" %>
   </div>
 
@@ -72,6 +72,7 @@
         document.getElementById("target_repair_time_not_breached").innerText = data.not_response_breached_tickets_last_30_days;
         document.getElementById("target_resolution_time_breached").innerText = data.resolution_breached_tickets_last_30_days;
         document.getElementById("target_resolution_time_not_breached").innerText = data.not_resolution_breached_tickets_last_30_days;
+        document.getElementById("no_sla_count").innerText = data.not_resolution_data_breached_tickets_last_30_days;
 
         // Re-render Pie Charts with Updated Data
         document.getElementById("responseTimeChart").innerHTML = "";


### PR DESCRIPTION
This pull request includes changes to the `dashboards` feature to add a new metric for tickets that have not breached any SLA data points. The changes involve updates to the controller, view, and JavaScript to display and handle this new metric.

Changes to add the new metric:

* [`app/controllers/dashboards_controller.rb`](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5R52-R70): Added calculation for `not_resolution_data_breached_tickets_last_30_days` to the `fetch_stats` method and included it in the `stats` hash.
* [`app/views/dashboards/index.html.erb`](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L25-R25): Updated the "No SLA Count" stat card to display the new metric `not_resolution_data_breached_tickets_last_30_days` instead of a hardcoded value.
* [`app/views/dashboards/index.html.erb`](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60R75): Modified JavaScript to update the "No SLA Count" element with the new metric value from the `stats` hash.