### PR TITLE
Bugfix/add data pie chart

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -15,37 +15,37 @@ class DashboardsController < ApplicationController
       total_tickets_last_30_days = Ticket.where(software_id: software).where('created_at >= ?', 30.days.ago).count
       breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_status: 'Breached')
         .count
 
       not_breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_status: 'Not Breached')
         .count
 
       response_breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_target_response_deadline: 'Breached')
         .count
 
       not_response_breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_target_response_deadline: 'Not Breached')
         .count
 
       resolution_breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_resolution_deadline: 'Breached')
         .count
 
       not_resolution_breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_resolution_deadline: 'Not Breached')
         .count
 

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -67,6 +67,14 @@ class DashboardsController < ApplicationController
         .group('users.first_name', 'users.last_name')
         .count
 
+      breached_resolution_tickets_per_assignee = SlaTicket
+        .joins(ticket: { taggings: :user }) # Ensures proper joins
+        .where(tickets: { software_id: software })
+        .where('tickets.created_at >= ?', 300.days.ago)
+        .where(sla_target_resolution_deadline: 'Breached')
+        .group('users.first_name', 'users.last_name')
+        .count
+
       stats = {
         total_tickets_last_30_days: total_tickets_last_30_days,
         breached_tickets_last_30_days: breached_tickets_last_30_days,
@@ -76,7 +84,8 @@ class DashboardsController < ApplicationController
         resolution_breached_tickets_last_30_days: resolution_breached_tickets_last_30_days,
         not_resolution_breached_tickets_last_30_days: not_resolution_breached_tickets_last_30_days,
         not_resolution_data_breached_tickets_last_30_days: not_resolution_data_breached_tickets_last_30_days,
-        breached_tickets_per_assignee: breached_tickets_per_assignee
+        breached_tickets_per_assignee: breached_tickets_per_assignee,
+        breached_resolution_tickets_per_assignee: breached_resolution_tickets_per_assignee
       }
 
       render json: stats

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -71,7 +71,7 @@ class DashboardsController < ApplicationController
         .joins(ticket: { taggings: :user }) # Ensures proper joins
         .where(tickets: { software_id: software })
         .where('tickets.created_at >= ?', 300.days.ago)
-        .where(sla_target_resolution_deadline: 'Breached')
+        .where(sla_resolution_deadline: 'Breached')
         .group('users.first_name', 'users.last_name')
         .count
 

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -77,14 +77,14 @@
         // Re-render Pie Charts with Updated Data
         document.getElementById("responseTimeChart").innerHTML = "";
         new Chartkick.PieChart("responseTimeChart", [
-          ["Breached", data.response_breached_tickets_last_30_days],
-          ["Not Breached", data.not_response_breached_tickets_last_30_days]
+          [`Breached: (${data.response_breached_tickets_last_30_days})`, data.response_breached_tickets_last_30_days],
+          [`Not Breached: (${data.not_response_breached_tickets_last_30_days})`, data.not_response_breached_tickets_last_30_days]
         ]);
 
         document.getElementById("resolutionTimeChart").innerHTML = "";
         new Chartkick.PieChart("resolutionTimeChart", [
-          ["Breached", data.resolution_breached_tickets_last_30_days],
-          ["Not Breached", data.not_resolution_breached_tickets_last_30_days]
+          [`Breached: (${data.resolution_breached_tickets_last_30_days})`, data.resolution_breached_tickets_last_30_days],
+          [`Not Breached: (${data.not_resolution_breached_tickets_last_30_days})`, data.not_resolution_breached_tickets_last_30_days]
         ]);
       })
       .catch(error => {

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -143,11 +143,15 @@
             legend: "right" // Move the legend to the right side
         });
 
-        document.getElementById("resolutionTimeChartAssignee").innerHTML = "";
-        new Chartkick.PieChart("resolutionTimeChartAssignee", [
-          [`Breached (${data.response_breached_tickets_last_30_days})`, data.response_breached_tickets_last_30_days],
-          [`Not Breached (${data.not_response_breached_tickets_last_30_days})`, data.not_response_breached_tickets_last_30_days]
-        ]);
+      document.getElementById("resolutionTimeChartAssignee").innerHTML = "";
+      let assigneeResolutionData = Object.entries(data.breached_resolution_tickets_per_assignee).map(([name, count]) => {
+            // Ensure name is correctly formatted
+            let formattedName = Array.isArray(name) ? name.join(" ") : String(name);
+            return [`${formattedName} (${count})`, count];
+        });
+        new Chartkick.PieChart("resolutionTimeChartAssignee", assigneeResolutionData, {
+            legend: "right" // Move the legend to the right side
+        });
       })
       .catch(error => {
         console.error("Error fetching stats:", error);

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -136,7 +136,7 @@
         document.getElementById("breachedTicketsAssigneeChart").innerHTML = "";
         let assigneeData = Object.entries(data.breached_tickets_per_assignee).map(([name, count]) => {
             // Ensure name is correctly formatted
-            let formattedName = Array.isArray(name) ? name.join(" ") : String(name);
+            let formattedName = String(name).replace(/[\[\]"]/g, ''); // Remove brackets and quotes
             return [`${formattedName} (${count})`, count];
         });
         new Chartkick.PieChart("breachedTicketsAssigneeChart", assigneeData, {
@@ -146,7 +146,7 @@
       document.getElementById("resolutionTimeChartAssignee").innerHTML = "";
       let assigneeResolutionData = Object.entries(data.breached_resolution_tickets_per_assignee).map(([name, count]) => {
             // Ensure name is correctly formatted
-            let formattedName = Array.isArray(name) ? name.join(" ") : String(name);
+            let formattedName = String(name).replace(/[\[\]"]/g, '');
             return [`${formattedName} (${count})`, count];
         });
         new Chartkick.PieChart("resolutionTimeChartAssignee", assigneeResolutionData, {

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -49,7 +49,7 @@
   </div>
 
   <!-- Charts Section -->
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-10">
       <div class="bg-white p-4 shadow-md rounded-lg">
         <h2 class="text-lg font-semibold mb-3 text-center">Response Time Assignees (Breached)</h2>
         <div id="breachedTicketsAssigneeChart">

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -11,7 +11,12 @@
 
     <h1 class="text-3xl font-bold">All Stats Within Last 30 Days</h1>
 
-    <button type="button" class="text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center">Refresh</button>
+    <button type="button" 
+      onclick="refreshStats()" 
+      class="text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center">
+      Refresh
+    </button>
+
   </div>
 
   <!-- Stats Section -->
@@ -42,9 +47,28 @@
       </div>
     </div>
   </div>
-</div>
+
+  <!-- Charts Section -->
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div class="bg-white p-4 shadow-md rounded-lg">
+        <h2 class="text-lg font-semibold mb-3 text-center">Response Time Assignees (Breached)</h2>
+        <div id="breachedTicketsAssigneeChart">
+          <%= pie_chart [["Breached", @stats[:response_breached_tickets_last_30_days]], ["Not Breached", @stats[:not_response_breached_tickets_last_30_days]]], id: "responseTimeChart" %>
+        </div>
+      </div>
+
+      <div class="bg-white p-4 shadow-md rounded-lg">
+        <h2 class="text-lg font-semibold mb-3 text-center">Target Resolution Time Assignees (Breached)</h2>
+        <div id="resolutionTimeChartAssignee">
+          <%= pie_chart [["Breached", @stats[:resolution_breached_tickets_last_30_days]], ["Not Breached", @stats[:not_resolution_breached_tickets_last_30_days]]], id: "resolutionTimeChart" %>
+        </div>
+      </div>
+    </div>
+  </div>
 
 <script>
+  let selectedSoftware = null;
+
   function filterDropdown() {
     let input = document.getElementById("search").value.toLowerCase();
     let dropdown = document.getElementById("dropdown");
@@ -58,10 +82,31 @@
   }
 
   function selectItem(element) {
-    const softwareName = element.textContent;
+    const softwareName = element.textContent.trim();
     document.getElementById("search").value = softwareName;
+    selectedSoftware = softwareName; // Store the selected software
+
+    // Remove 'selected' class from all items
+    document.querySelectorAll(".dropdown-item").forEach(item => {
+      item.classList.remove("selected");
+    });
+
+    // Add 'selected' class to clicked item
+    element.classList.add("selected");
     document.getElementById("dropdown").classList.add("hidden");
 
+    fetchStats(softwareName); // Call the fetch function
+  }
+  
+  function refreshStats() {
+    if (selectedSoftware) {
+      fetchStats(selectedSoftware);
+    } else {
+      alert("Please select a software first.");
+    }
+  }
+
+  function fetchStats(softwareName) {
     fetch(`/dashboards/fetch_stats?software_name=${softwareName}`)
       .then(response => response.json())
       .then(data => {
@@ -74,17 +119,34 @@
         document.getElementById("target_resolution_time_not_breached").innerText = data.not_resolution_breached_tickets_last_30_days;
         document.getElementById("no_sla_count").innerText = data.not_resolution_data_breached_tickets_last_30_days;
 
-        // Re-render Pie Charts with Updated Data
+        // Refresh charts
         document.getElementById("responseTimeChart").innerHTML = "";
         new Chartkick.PieChart("responseTimeChart", [
-          [`Breached: (${data.response_breached_tickets_last_30_days})`, data.response_breached_tickets_last_30_days],
-          [`Not Breached: (${data.not_response_breached_tickets_last_30_days})`, data.not_response_breached_tickets_last_30_days]
+          [`Breached (${data.response_breached_tickets_last_30_days})`, data.response_breached_tickets_last_30_days],
+          [`Not Breached (${data.not_response_breached_tickets_last_30_days})`, data.not_response_breached_tickets_last_30_days]
         ]);
 
         document.getElementById("resolutionTimeChart").innerHTML = "";
         new Chartkick.PieChart("resolutionTimeChart", [
-          [`Breached: (${data.resolution_breached_tickets_last_30_days})`, data.resolution_breached_tickets_last_30_days],
-          [`Not Breached: (${data.not_resolution_breached_tickets_last_30_days})`, data.not_resolution_breached_tickets_last_30_days]
+          [`Breached (${data.resolution_breached_tickets_last_30_days})`, data.resolution_breached_tickets_last_30_days],
+          [`Not Breached (${data.not_resolution_breached_tickets_last_30_days})`, data.not_resolution_breached_tickets_last_30_days]
+        ]);
+
+        // Generate Assignee Breached Tickets Pie Chart
+        document.getElementById("breachedTicketsAssigneeChart").innerHTML = "";
+        let assigneeData = Object.entries(data.breached_tickets_per_assignee).map(([name, count]) => {
+            // Ensure name is correctly formatted
+            let formattedName = Array.isArray(name) ? name.join(" ") : String(name);
+            return [`${formattedName} (${count})`, count];
+        });
+        new Chartkick.PieChart("breachedTicketsAssigneeChart", assigneeData, {
+            legend: "right" // Move the legend to the right side
+        });
+
+        document.getElementById("resolutionTimeChartAssignee").innerHTML = "";
+        new Chartkick.PieChart("resolutionTimeChartAssignee", [
+          [`Breached (${data.response_breached_tickets_last_30_days})`, data.response_breached_tickets_last_30_days],
+          [`Not Breached (${data.not_response_breached_tickets_last_30_days})`, data.not_response_breached_tickets_last_30_days]
         ]);
       })
       .catch(error => {


### PR DESCRIPTION
This pull request includes significant updates to the `fetch_stats` method in the `dashboards_controller.rb` file and enhancements to the `index.html.erb` view for the dashboards. The changes extend the data analysis period, add new statistics, and improve the user interface with new charts and interactive elements.

Key changes include:

### Data Analysis Period Extension
* Extended the data analysis period from 30 days to 300 days in multiple queries within the `fetch_stats` method.

### New Statistics
* Added calculations for `breached_tickets_per_assignee` and `breached_resolution_tickets_per_assignee` to the `fetch_stats` method.
* Updated the `stats` hash to include the new statistics.

### User Interface Enhancements
* Modified the "Refresh" button to call a new `refreshStats` JavaScript function, allowing users to refresh statistics dynamically.
* Added new sections in the HTML to display pie charts for "Response Time Assignees (Breached)" and "Target Resolution Time Assignees (Breached)".
* Implemented JavaScript functions to handle software selection, refresh statistics, and update charts dynamically. [[1]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L61-R109) [[2]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L77-R154)