### PR TITLE
Bugfix/projects pie

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -72,12 +72,12 @@ class DashboardsController < ApplicationController
         .group('users.first_name', 'users.last_name')
         .count
 
-      breached_resolution_tickets_per_assignee = SlaTicket
-        .joins(ticket: { taggings: :user }) # Ensures proper joins
+      breached_resolution_tickets_per_project = SlaTicket
+        .joins(ticket: :project) # Join the projects table
         .where(tickets: { software_id: software })
         .where('tickets.created_at >= ?', 30.days.ago)
-        .where(sla_resolution_deadline: 'Breached')
-        .group('users.first_name', 'users.last_name')
+        .where(sla_target_response_deadline: 'Breached')
+        .group('projects.title') # Group by project title
         .count
 
       stats = {
@@ -89,7 +89,7 @@ class DashboardsController < ApplicationController
         resolution_breached_tickets_last_30_days: resolution_breached_tickets_last_30_days,
         not_resolution_breached_tickets_last_30_days: not_resolution_breached_tickets_last_30_days,
         breached_tickets_per_assignee: breached_tickets_per_assignee,
-        breached_resolution_tickets_per_assignee: breached_resolution_tickets_per_assignee,
+        breached_resolution_tickets_per_project: breached_resolution_tickets_per_project,
         pending_resolution_30_days: pending_resolution_30_days,
         pending_initial_response_30_days: pending_initial_response_30_days,
         pending_target_response_30_days: pending_target_response_30_days

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -12,62 +12,62 @@ class DashboardsController < ApplicationController
     software = Software.find_by(name: software_name)&.id
 
     if software
-      total_tickets_last_30_days = Ticket.where(software_id: software).where('created_at >= ?', 30.days.ago).count
+      total_tickets_last_30_days = Ticket.where(software_id: software).where('created_at >= ?', 300.days.ago).count
       breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_status: 'Breached')
         .count
 
       not_breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_status: 'Not Breached')
         .count
 
       response_breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_target_response_deadline: 'Breached')
         .count
 
       not_response_breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_target_response_deadline: 'Not Breached')
         .count
 
       resolution_breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_resolution_deadline: 'Breached')
         .count
 
       not_resolution_breached_tickets_last_30_days = SlaTicket.joins(:ticket)
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_resolution_deadline: 'Not Breached')
         .count
 
       pending_resolution_30_days = Ticket.where(software_id: software)
-        .where('created_at >= ?', 30.days.ago)
+        .where('created_at >= ?', 300.days.ago)
         .where(id: SlaTicket.where(sla_resolution_deadline: nil).select(:ticket_id))
         .count
 
       pending_initial_response_30_days = Ticket.where(software_id: software)
-        .where('created_at >= ?', 30.days.ago)
+        .where('created_at >= ?', 300.days.ago)
         .where(id: SlaTicket.where(sla_status: nil).select(:ticket_id))
         .count
 
       pending_target_response_30_days = Ticket.where(software_id: software)
-        .where('created_at >= ?', 30.days.ago)
+        .where('created_at >= ?', 300.days.ago)
         .where(id: SlaTicket.where(sla_target_response_deadline: nil).select(:ticket_id))
         .count
 
       breached_tickets_per_assignee = SlaTicket
         .joins(ticket: { taggings: :user }) # Ensures proper joins
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_target_response_deadline: 'Breached')
         .group('users.first_name', 'users.last_name')
         .count
@@ -75,7 +75,7 @@ class DashboardsController < ApplicationController
       breached_resolution_tickets_per_project = SlaTicket
         .joins(ticket: :project) # Join the projects table
         .where(tickets: { software_id: software })
-        .where('tickets.created_at >= ?', 30.days.ago)
+        .where('tickets.created_at >= ?', 300.days.ago)
         .where(sla_target_response_deadline: 'Breached')
         .group('projects.title') # Group by project title
         .count

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -56,14 +56,14 @@
   <!-- Charts Section -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-10">
       <div class="bg-white p-4 shadow-md rounded-lg">
-        <h2 class="text-lg font-semibold mb-3 text-center">Target Response Time Assignees (Breached)</h2>
+        <h2 class="text-lg font-semibold mb-3 text-center">Target Repair Time Assignees (Breached)</h2>
         <div id="breachedTicketsAssigneeChart">
           <%= pie_chart [["Breached", @stats[:response_breached_tickets_last_30_days]], ["Not Breached", @stats[:not_response_breached_tickets_last_30_days]]], id: "responseTimeChart" %>
         </div>
       </div>
 
       <div class="bg-white p-4 shadow-md rounded-lg">
-        <h2 class="text-lg font-semibold mb-3 text-center">Target Response Time Projects (Breached)</h2>
+        <h2 class="text-lg font-semibold mb-3 text-center">Target Repair Time Projects (Breached)</h2>
         <div id="resolutionTimeChartAssignee">
           <%= pie_chart [["Breached", @stats[:resolution_breached_tickets_last_30_days]], ["Not Breached", @stats[:not_resolution_breached_tickets_last_30_days]]], id: "resolutionTimeChart" %>
         </div>
@@ -154,7 +154,7 @@
         let assigneeResolutionData = Object.entries(data.breached_resolution_tickets_per_project).map(([name, count]) => {
               // Ensure name is correctly formatted
               let formattedName = String(name).replace(/[\[\]"]/g, '');
-              return [`${formattedName} (${count})`, count];
+              return [`${formattedName} (${count} ticket(s))`, count];
           });
           new Chartkick.PieChart("resolutionTimeChartAssignee", assigneeResolutionData, {
               legend: "right" // Move the legend to the right side

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -56,14 +56,14 @@
   <!-- Charts Section -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-10">
       <div class="bg-white p-4 shadow-md rounded-lg">
-        <h2 class="text-lg font-semibold mb-3 text-center">Response Time Assignees (Breached)</h2>
+        <h2 class="text-lg font-semibold mb-3 text-center">Target Response Time Assignees (Breached)</h2>
         <div id="breachedTicketsAssigneeChart">
           <%= pie_chart [["Breached", @stats[:response_breached_tickets_last_30_days]], ["Not Breached", @stats[:not_response_breached_tickets_last_30_days]]], id: "responseTimeChart" %>
         </div>
       </div>
 
       <div class="bg-white p-4 shadow-md rounded-lg">
-        <h2 class="text-lg font-semibold mb-3 text-center">Target Resolution Time Assignees (Breached)</h2>
+        <h2 class="text-lg font-semibold mb-3 text-center">Target Response Time Projects (Breached)</h2>
         <div id="resolutionTimeChartAssignee">
           <%= pie_chart [["Breached", @stats[:resolution_breached_tickets_last_30_days]], ["Not Breached", @stats[:not_resolution_breached_tickets_last_30_days]]], id: "resolutionTimeChart" %>
         </div>
@@ -150,19 +150,19 @@
             legend: "right" // Move the legend to the right side
         });
 
-      document.getElementById("resolutionTimeChartAssignee").innerHTML = "";
-      let assigneeResolutionData = Object.entries(data.breached_resolution_tickets_per_assignee).map(([name, count]) => {
-            // Ensure name is correctly formatted
-            let formattedName = String(name).replace(/[\[\]"]/g, '');
-            return [`${formattedName} (${count})`, count];
+        document.getElementById("resolutionTimeChartAssignee").innerHTML = "";
+        let assigneeResolutionData = Object.entries(data.breached_resolution_tickets_per_project).map(([name, count]) => {
+              // Ensure name is correctly formatted
+              let formattedName = String(name).replace(/[\[\]"]/g, '');
+              return [`${formattedName} (${count})`, count];
+          });
+          new Chartkick.PieChart("resolutionTimeChartAssignee", assigneeResolutionData, {
+              legend: "right" // Move the legend to the right side
+          });
+        })
+        .catch(error => {
+          console.error("Error fetching stats:", error);
         });
-        new Chartkick.PieChart("resolutionTimeChartAssignee", assigneeResolutionData, {
-            legend: "right" // Move the legend to the right side
-        });
-      })
-      .catch(error => {
-        console.error("Error fetching stats:", error);
-      });
   }
 
   document.addEventListener("click", function(event) {


### PR DESCRIPTION
This pull request includes several changes to the `fetch_stats` method in `dashboards_controller.rb` and updates to the corresponding views in `dashboards/index.html.erb`. The primary changes are extending the time range for ticket queries from 30 days to 300 days and modifying how breached resolution tickets are grouped and displayed.

Changes to ticket queries:

* [`app/controllers/dashboards_controller.rb`](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L15-R80): Updated the time range for ticket queries from 30 days to 300 days.

Changes to data grouping:

* [`app/controllers/dashboards_controller.rb`](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L15-R80): Changed the grouping of breached resolution tickets from assignees to projects. [[1]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L15-R80) [[2]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L92-R92)

Changes to view labels and data display:

* [`app/views/dashboards/index.html.erb`](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L59-R66): Updated the labels in the charts to reflect the new grouping by projects instead of assignees. [[1]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L59-R66) [[2]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L154-R157)