### PR TITLE
Views on tickets to select

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -17,7 +17,13 @@ class DataCenterController < ApplicationController
                  end
 
       @tickets = @tickets.where(projects: { client_id: params[:client_id] }) if params[:client_id].present?
-      @tickets = @tickets.joins(:statuses).where(statuses: { name: params[:status] }) if params[:status].present?
+
+      @tickets = if params[:status].blank?
+                   @tickets.joins(:statuses)
+                 else
+                   @tickets.joins(:statuses).where(statuses: { name: params[:status] })
+                 end
+
       @status_counts = @tickets.joins(:statuses).group('statuses.name').count
 
       respond_to do |format|

--- a/app/views/data_center/cease_fire_report.html.erb
+++ b/app/views/data_center/cease_fire_report.html.erb
@@ -15,8 +15,24 @@
         <%= f.select :status,
                      options_from_collection_for_select(Status.where(name: ['New', 'Closed', 'Resolved', 'Reopened', 'Under Development', 'Work in Progress', 'QA Testing', 'Awaiting Build', 'Client Confirmation Pending', 'On-Hold', 'Assigned', 'Declined']), :name, :name, params[:status]),
                      { include_blank: 'All Statuses', multiple: true },
-                     class: "border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full" %>
+                     class: "border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full", id: "statusSelect" %>
       </div>
+      <script>
+        document.addEventListener('turbo:load', function() {
+          const statusSelect = document.getElementById('statusSelect');
+
+          statusSelect.addEventListener('change', function() {
+            const allStatuses = Array.from(statusSelect.options).slice(1); // Exclude the blank option
+            const blankOption = statusSelect.options[0];
+
+            if (blankOption.selected) {
+              allStatuses.forEach(option => option.selected = true);
+            } else {
+              blankOption.selected = false;
+            }
+          });
+        });
+      </script>
 
       <div class="flex flex-col gap-2 w-full sm:w-1/2 md:w-1/3">
         <%= f.label :client_id, "Client", class: "capitalize text-sm font-bold w-full align-middle pt-3" %>


### PR DESCRIPTION
This pull request includes changes to the `cease_fire_report` functionality in the `data_center_controller` and its corresponding view. The main changes involve improving the handling of the status filter and enhancing the user interface for status selection.

### Improvements to status filter handling:

* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL20-R26): Modified the `cease_fire_report` method to handle cases where the status parameter is blank, ensuring that all statuses are included if no specific status is selected.

### Enhancements to user interface:

* [`app/views/data_center/cease_fire_report.html.erb`](diffhunk://#diff-413ef0b0ccf29cf8ad0c2dae1da8e1b6bdfcd6656d3eede0a1db94ee98b1cc5eL18-R35): Added an `id` attribute to the status select element and included a JavaScript script to automatically select all statuses when the "All Statuses" option is chosen.