### PR TITLE
Views on tickets to select

### DIFF
--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -147,7 +147,6 @@
           return [`${formattedName} (${count})`, count];
         });
         new Chartkick.PieChart("breachedTicketsAssigneeChart", assigneeData, {
-          colors: ["#ff0000", "#36a2eb"],
           legend: "right" // Move the legend to the right side
         });
 
@@ -158,7 +157,6 @@
           return [`${formattedName} (${count} ticket(s))`, count];
         });
         new Chartkick.PieChart("resolutionTimeChartAssignee", assigneeResolutionData, {
-          colors: ["#ff0000", "#36a2eb"],
           legend: "right" // Move the legend to the right side
         });
       })


### PR DESCRIPTION
This pull request includes changes to the `app/views/dashboards/index.html.erb` file to improve the visualization of charts by removing the hardcoded colors and moving the legend to the right side.

Visualization improvements:

* [`app/views/dashboards/index.html.erb`](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L150): Removed hardcoded colors from the `breachedTicketsAssigneeChart` and `resolutionTimeChartAssignee` charts, and positioned the legend to the right side for better readability. [[1]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L150) [[2]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L161)