### PR TITLE
Views on tickets to select

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -29,7 +29,7 @@ class DashboardsController < ApplicationController
         .where(users: { id: user_ids })
         .where('tickets.created_at >= ?', 30.days.ago)
         .joins(:sla_tickets)
-        .where(sla_tickets: { sla_status: 'Not Breached' })
+        .where(sla_tickets: { sla_status: ['Not Breached', nil] })
         .count
       # Breached response deadline tickets per Team
       response_breached_tickets_last_30_days = Ticket.joins(:users)
@@ -43,7 +43,7 @@ class DashboardsController < ApplicationController
         .where(users: { id: user_ids })
         .where('tickets.created_at >= ?', 30.days.ago)
         .joins(:sla_tickets)
-        .where(sla_tickets: { sla_target_response_deadline: 'Not Breached' })
+        .where(sla_tickets: { sla_target_response_deadline: ['Not Breached', nil] })
         .count
       # Breached resolution deadline tickets per Team
       resolution_breached_tickets_last_30_days = Ticket.joins(:users)
@@ -57,24 +57,7 @@ class DashboardsController < ApplicationController
         .where(users: { id: user_ids })
         .where('tickets.created_at >= ?', 30.days.ago)
         .joins(:sla_tickets)
-        .where(sla_tickets: { sla_resolution_deadline: 'Not Breached' })
-        .count
-
-      # Pending resolution tickets per Team to be removed!
-
-      pending_resolution_30_days = Ticket.where(user_id: user_ids)
-        .where('created_at >= ?', 30.days.ago)
-        .where(id: SlaTicket.where(sla_resolution_deadline: nil).select(:ticket_id))
-        .count
-
-      pending_initial_response_30_days = Ticket.where(user_id: user_ids)
-        .where('created_at >= ?', 30.days.ago)
-        .where(id: SlaTicket.where(sla_status: nil).select(:ticket_id))
-        .count
-
-      pending_target_response_30_days = Ticket.where(user_id: user_ids)
-        .where('created_at >= ?', 30.days.ago)
-        .where(id: SlaTicket.where(sla_target_response_deadline: nil).select(:ticket_id))
+        .where(sla_tickets: { sla_resolution_deadline: ['Not Breached', nil] })
         .count
 
       # Breached tickets per assignee to select per team working
@@ -123,11 +106,8 @@ class DashboardsController < ApplicationController
         not_resolution_breached_tickets_last_30_days: not_resolution_breached_tickets_last_30_days,
         breached_tickets_per_assignee: breached_tickets_per_assignee,
         breached_resolution_tickets_per_project: breached_resolution_tickets_per_project,
-        pending_resolution_30_days: pending_resolution_30_days,
-        pending_initial_response_30_days: pending_initial_response_30_days,
         breached_tickets_resolved_per_assignee: breached_tickets_resolved_per_assignee,
-        breached_resolution_resolved_tickets_per_project: breached_resolution_resolved_tickets_per_project,
-        pending_target_response_30_days: pending_target_response_30_days
+        breached_resolution_resolved_tickets_per_project: breached_resolution_resolved_tickets_per_project
       }
 
       render json: stats

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -19,17 +19,16 @@
   </div>
 
   <!-- Stats Section -->
-  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-6 mb-8 mt-6">
-    <%= render 'dashboards/stat_card', title: "Initial Response Time - Breached", value: @stats[:breached_tickets_last_30_days], id: "initial_response_time_breached" %>
-    <%= render 'dashboards/stat_card', title: "Initial Response Time - Not Breached", value: @stats[:not_breached_tickets_last_30_days], id: "initial_response_time_not_breached" %>
-    <%= render 'dashboards/stat_card', title: "Initial Response Time - In Progress & Before Status Change", value: @stats[:pending_initial_response_30_days], id: "initial_response_pending" %>
-    <%= render 'dashboards/stat_card', title: "Target Repair Time - Breached", value: @stats[:response_breached_tickets_last_30_days], id: "target_repair_time_breached" %>
-    <%= render 'dashboards/stat_card', title: "Target Repair Time - Not Breached", value: @stats[:not_response_breached_tickets_last_30_days], id: "target_repair_time_not_breached" %>
-    <%= render 'dashboards/stat_card', title: "Target Repair Time - In Progress & Before Status Change", value: @stats[:pending_target_response_30_days], id: "target_repair_time_pending" %>
-    <%= render 'dashboards/stat_card', title: "Target Resolution Time - Breached", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached" %>
-    <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached" %>
-    <%= render 'dashboards/stat_card', title: "Target Resolution Time - In Progress & Before Status Change", value: @stats[:pending_resolution_30_days], id: "target_resolution_time_pending" %>
-    <div class="col-span-1 sm:col-span-2 md:col-span-3 lg:col-span-3">
+  <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 gap-6 mb-8 mt-6">
+    <%= render 'dashboards/stat_card', title: "Initial Response Time - Breached", value: @stats[:breached_tickets_last_30_days], id: "initial_response_time_breached", class: 'col-span-1' %>
+    <%= render 'dashboards/stat_card', title: "Initial Response Time - Not Breached", value: @stats[:not_breached_tickets_last_30_days], id: "initial_response_time_not_breached", class: 'col-span-1'  %>
+
+    <%= render 'dashboards/stat_card', title: "Target Repair Time - Breached", value: @stats[:response_breached_tickets_last_30_days], id: "target_repair_time_breached", class: 'col-span-1'  %>
+    <%= render 'dashboards/stat_card', title: "Target Repair Time - Not Breached", value: @stats[:not_response_breached_tickets_last_30_days], id: "target_repair_time_not_breached", class: 'col-span-1'  %>
+
+    <%= render 'dashboards/stat_card', title: "Target Resolution Time - Breached", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
+    <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached", class: 'col-span-1'  %>
+    <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
       <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days"%>
     </div>
   </div>
@@ -153,9 +152,6 @@
         document.getElementById("target_repair_time_not_breached").innerText = data.not_response_breached_tickets_last_30_days;
         document.getElementById("target_resolution_time_breached").innerText = data.resolution_breached_tickets_last_30_days;
         document.getElementById("target_resolution_time_not_breached").innerText = data.not_resolution_breached_tickets_last_30_days;
-        document.getElementById("initial_response_pending").innerText = data.pending_initial_response_30_days;
-        document.getElementById("target_repair_time_pending").innerText = data.pending_target_response_30_days;
-        document.getElementById("target_resolution_time_pending").innerText = data.pending_resolution_30_days;
 
         // Refresh charts
         document.getElementById("responseTimeChart").innerHTML = "";


### PR DESCRIPTION
This pull request includes several changes to the `fetch_stats` method in `app/controllers/dashboards_controller.rb` and updates to the `app/views/dashboards/index.html.erb` view. The primary focus is on refining the statistics calculations and simplifying the dashboard view by removing redundant stats.

### Changes to `fetch_stats` method:

* Modified the `where` clauses to include `nil` values for `sla_status`, `sla_target_response_deadline`, and `sla_resolution_deadline` to ensure tickets with no SLA status are also counted. [[1]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L32-R32) [[2]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L46-R46) [[3]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L60-R60)
* Removed the calculation and inclusion of `pending_resolution_30_days`, `pending_initial_response_30_days`, and `pending_target_response_30_days` stats. [[1]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L60-R60) [[2]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L126-R110)

### Updates to the dashboard view:

* Simplified the stats section by removing the display of pending stats and adjusting the grid layout to a two-column format.
* Removed JavaScript code that updates the now-removed pending stats.