### PR TITLE
Orm report status fix

### DIFF
--- a/app/views/data_center/cease_fire_report.html.erb
+++ b/app/views/data_center/cease_fire_report.html.erb
@@ -50,6 +50,7 @@
           <input type="hidden" id="selectedClientId" name="client_id">
         </div>
 
+
       <div class="flex flex-col gap-2 w-full sm:w-1/2 md:w-1/3">
         <%= f.label :start_date, "Start Date", class: "capitalize text-sm font-bold w-full align-middle pt-3" %>
         <%= f.date_field :start_date, value: params[:start_date], class: "border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full" %>
@@ -154,7 +155,7 @@
               <% end %>
             <% end %></td>
           <td class="border px-4 py-2"><%= ticket.user.name %></td>
-          <td class="border px-4 py-2"><%= ticket.content.to_plain_text.truncate(800) %></td>
+          <td class="border px-4 py-2"><%= ticket.content.to_plain_text.truncate(3000) %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/data_center/cease_fire_report.html.erb
+++ b/app/views/data_center/cease_fire_report.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.has_role?(:admin) or current_user.has_role?('project manager') %>
-  <h1 class="flex justify-center text-2xl font-bold mb-4">Cease Fire Report</h1>
+  <h1 class="flex justify-center text-2xl font-bold mb-4">Cease Fire Report <span class="text-xs p-2 text-red">(Leave the lower part blank if you want*)</span> </h1>
 <% else %>
   <h1 class="flex justify-center text-2xl font-bold mb-4">Status Report</h1>
 <% end %>
@@ -30,7 +30,7 @@
         });
       </script>
 
-        <div class="flex flex-col gap-2 w-full sm:w-1/2 md:w-1/3 relative">
+        <div class="flex flex-col gap-2 w-full sm:w-1/2 md:w-1/3">
           <label for="searchClient" class="capitalize text-sm font-bold w-full align-middle pt-3">Client</label>
 
           <!-- Searchable Input -->

--- a/app/views/data_center/orm_report.html.erb
+++ b/app/views/data_center/orm_report.html.erb
@@ -4,14 +4,13 @@
 <div class="p-2 w-full">
   <%= form_with url: orm_report_path, method: :get, local: true do |f| %>
     <div class="flex flex-wrap justify-center gap-2">
-      <div class="flex flex-col gap-2 w-full sm:w-1/6 md:w-1/6">
-        <%= f.label :days, "Closed & Resolved for the last (days)" %>
+      <div class="flex flex-col gap-2">
+        <%= f.label :days, "Closed & Resolved for the last (days)", class: "capitalize text-sm font-bold w-full align-middle p-2" %>
         <%= f.number_field :days, value: params[:days], class: "border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full p-2" %>
       </div>
-      <div class="flex flex-col gap-2 w-full sm:w-1/6 md:w-1/6">
-  <%= f.label :client_id, "Client", class: "capitalize text-sm font-bold w-full align-middle pt-2" %>
-
-  <div class="relative w-full">
+      <div class="flex flex-col gap-2">
+        <%= f.label :client_id, "Client", class: "capitalize text-sm font-bold w-full align-middle p-2" %>
+        <div class="relative w-full">
     <!-- Searchable Input -->
         <input type="text" id="searchClient" class="border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full p-2" placeholder="Search Client..." onkeyup="filterClientDropdown()">
 
@@ -76,16 +75,16 @@
     <table id="orm_report" class="table-auto w-full">
       <thead>
       <tr>
-        <th class="border border-black px-4 py-2">Created at</th>
-        <th class="border border-black px-4 py-2">Project Name</th>
         <th class="border border-black px-4 py-2">Ticket ID</th>
-        <th class="border border-black px-4 py-2">Issue Type</th>
         <th class="border border-black px-4 py-2">Summary</th>
-        <th class="border border-black px-4 py-2">Status</th>
-        <th class="border border-black px-4 py-2">Severity</th>
+        <th class="border border-black px-4 py-2">Issue Type</th>
         <th class="border border-black px-4 py-2">Assignee</th>
         <th class="border border-black px-4 py-2">Reporter</th>
-        <th class="border border-black px-4 py-2">Details</th>
+        <th class="border border-black px-4 py-2">Severity</th>
+        <th class="border border-black px-4 py-2">Status</th>
+        <th class="border border-black px-4 py-2">Created at</th>
+        <th class="border border-black px-4 py-2">updated at</th>
+
       </tr>
       </thead>
       <tbody>
@@ -121,16 +120,19 @@
                          ''
                        end %>
         <tr class="<%= row_class %> text-white text-bold">
-          <td class="border px-4 py-2"><%= ticket.created_at.strftime("%d-%b-%Y") %></td>
-          <td class="capitalize border px-4 py-2"><%= ticket.project.title %></td>
           <td class="border px-4 py-2"><%= ticket.unique_id %></td>
-          <td class="border px-4 py-2"><%= ticket.issue %></td>
           <td class="border px-4 py-2"><%= ticket.subject %></td>
-          <td class="border px-4 py-2"><%= ticket.statuses.first&.name || 'N/A' %></td>
-          <td class="border px-4 py-2"><%= ticket.priority %></td>
+          <td class="border px-4 py-2"><%= ticket.issue %></td>
           <td class="border px-4 py-2"><%= ticket.users.map(&:name).select(&:present?).join(', ') %></td>
           <td class="border px-4 py-2"><%= ticket.user.name %></td>
-          <td class="border px-4 py-2"><%= ticket.content.to_plain_text.truncate(800) %></td>
+          <td class="border px-4 py-2"><%= ticket.priority %></td>
+          <td class="border px-4 py-2"><%= ticket.statuses.first&.name || 'N/A' %></td>
+          <td class="border px-4 py-2"><%= ticket.created_at.strftime("%d-%b-%Y") %></td>
+          <td class="border px-4 py-2"><%= ticket.updated_at.strftime("%d-%b-%Y") %></td>
+
+
+
+
         </tr>
       <% end %>
       </tbody>


### PR DESCRIPTION
This pull request involves several updates and improvements to the `cease_fire_report.html.erb` and `orm_report.html.erb` views in the `data_center` directory. The changes focus on enhancing the user interface and modifying the structure of the reports.

Changes to `cease_fire_report.html.erb`:

* Added a note to the `Cease Fire Report` header for additional user instructions.
* Removed an unnecessary `relative` class from a `div` element to streamline the layout.
* Increased the truncation limit for ticket content from 800 to 3000 characters to provide more detailed information.

Changes to `orm_report.html.erb`:

* Updated labels and input fields to improve consistency and readability by adding class attributes.
* Reordered and updated table columns to include additional information such as `updated at` and rearranged existing columns for better clarity. [[1]](diffhunk://#diff-3ad4e1036a2b20b618eb934fbfe128363954459d52936cd356d7368acfc11b61L79-R87) [[2]](diffhunk://#diff-3ad4e1036a2b20b618eb934fbfe128363954459d52936cd356d7368acfc11b61L124-R135)