### PR TITLE
Fix for ceasefire

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,7 +58,7 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: false
 Lint/DuplicateBranch:
-  Enabled: false
+  Enabled: true
 Style/HashEachMethods:
   Enabled: false
 Style/HashTransformKeys:

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -20,10 +20,10 @@
 
   <!-- Stats Section -->
   <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 gap-6 mb-8 mt-6">
-    <%= link_to dashboards_tickets_path(team_name: @team, type: 'initial_response_time_breached') do %>
+    <%= link_to dashboards_tickets_path(:team_name,  type: 'initial_response_time_breached') do %>
       <%= render 'dashboards/stat_card', title: "Initial Response Time - Breached", value: @stats[:breached_tickets_last_30_days], id: "initial_response_time_breached", class: 'col-span-1' %>
     <% end %>
-    <%= link_to dashboards_tickets_path(team_name: @team, type: 'initial_response_time_not_breached') do %>
+    <%= link_to dashboards_tickets_path(:team_name, type: 'initial_response_time_not_breached') do %>
       <%= render 'dashboards/stat_card', title: "Initial Response Time - Not Breached", value: @stats[:not_breached_tickets_last_30_days], id: "initial_response_time_not_breached", class: 'col-span-1'  %>
     <% end %>
     <%= link_to dashboards_tickets_path(team_name: @team, type: 'target_repair_time_breached') do %>
@@ -36,7 +36,11 @@
     <%= render 'dashboards/stat_card', title: "Target Resolution Time - Breached", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
     <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached", class: 'col-span-1'  %>
     <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
-      <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days"%>
+      <% @teams.each do |team| %>
+        <%= link_to dashboards_tickets_path(team_name: team.name, type: 'total_tickets_last_30_days') do %>
+          <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days" %>
+        <% end %>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -20,28 +20,35 @@
 
   <!-- Stats Section -->
   <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 gap-6 mb-8 mt-6">
-    <% @teams.each do |team| %>
-    <%= link_to dashboards_tickets_path(team_name: team.name, type: 'initial_response_time_breached') do %>
+
+    <%= link_to dashboards_tickets_path(team_name: @teams.first&.name, type: 'initial_response_time_breached') do %>
       <%= render 'dashboards/stat_card', title: "Initial Response Time - Breached", value: @stats[:breached_tickets_last_30_days], id: "initial_response_time_breached", class: 'col-span-1' %>
     <% end %>
-      <% end %>
-    <%= link_to dashboards_tickets_path(:team_name, type: 'initial_response_time_not_breached') do %>
+
+
+    <%= link_to dashboards_tickets_path(team_name: @teams.first&.name, type: 'initial_response_time_not_breached') do %>
       <%= render 'dashboards/stat_card', title: "Initial Response Time - Not Breached", value: @stats[:not_breached_tickets_last_30_days], id: "initial_response_time_not_breached", class: 'col-span-1'  %>
     <% end %>
-    <%= link_to dashboards_tickets_path(team_name: @team, type: 'target_repair_time_breached') do %>
+
+
+    <%= link_to dashboards_tickets_path(team_name: @teams.first&.name, type: 'target_repair_time_breached') do %>
       <%= render 'dashboards/stat_card', title: "Target Repair Time - Breached", value: @stats[:response_breached_tickets_last_30_days], id: "target_repair_time_breached", class: 'col-span-1'  %>
     <% end %>
-    <%= link_to dashboards_tickets_path(team_name: @team, type: 'target_repair_time_not_breached') do %>
+
+
+    <%= link_to dashboards_tickets_path(team_name: @teams.first&.name, type: 'target_repair_time_not_breached') do %>
       <%= render 'dashboards/stat_card', title: "Target Repair Time - Not Breached", value: @stats[:not_response_breached_tickets_last_30_days], id: "target_repair_time_not_breached", class: 'col-span-1'  %>
     <% end %>
+    <%= link_to dashboards_tickets_path(team_name: @teams.first&.name, type: 'target_resolution_time_breached') do %>
+      <%= render 'dashboards/stat_card', title: "Target Resolution Time - Breached", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'%>
+    <% end %>
+    <%= link_to dashboards_tickets_path(team_name: @teams.first&.name, type: 'target_resolution_time_not_breached') do %>
+      <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached", class: 'col-span-1'  %>
 
-    <%= render 'dashboards/stat_card', title: "Target Resolution Time - Breached", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
-    <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached", class: 'col-span-1'  %>
+    <% end %>
     <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
-      <% @teams.each do |team| %>
-          <%= link_to dashboards_tickets_path(team_name: team.name, type: 'total_tickets_last_30_days') do %>
-            <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days" %>
-          <% end %>
+      <%= link_to dashboards_tickets_path(team_name: @teams.first&.name, type: 'total_tickets_last_30_days') do %>
+        <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days" %>
       <% end %>
     </div>
   </div>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -20,9 +20,11 @@
 
   <!-- Stats Section -->
   <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 gap-6 mb-8 mt-6">
-    <%= link_to dashboards_tickets_path(:team_name,  type: 'initial_response_time_breached') do %>
+    <% @teams.each do |team| %>
+    <%= link_to dashboards_tickets_path(team_name: team.name, type: 'initial_response_time_breached') do %>
       <%= render 'dashboards/stat_card', title: "Initial Response Time - Breached", value: @stats[:breached_tickets_last_30_days], id: "initial_response_time_breached", class: 'col-span-1' %>
     <% end %>
+      <% end %>
     <%= link_to dashboards_tickets_path(:team_name, type: 'initial_response_time_not_breached') do %>
       <%= render 'dashboards/stat_card', title: "Initial Response Time - Not Breached", value: @stats[:not_breached_tickets_last_30_days], id: "initial_response_time_not_breached", class: 'col-span-1'  %>
     <% end %>
@@ -37,9 +39,9 @@
     <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached", class: 'col-span-1'  %>
     <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
       <% @teams.each do |team| %>
-        <%= link_to dashboards_tickets_path(team_name: team.name, type: 'total_tickets_last_30_days') do %>
-          <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days" %>
-        <% end %>
+          <%= link_to dashboards_tickets_path(team_name: team.name, type: 'total_tickets_last_30_days') do %>
+            <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days" %>
+          <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/data_center/cease_fire_report.html.erb
+++ b/app/views/data_center/cease_fire_report.html.erb
@@ -1,7 +1,7 @@
 <% if current_user.has_role?(:admin) or current_user.has_role?('project manager') %>
-  <<h1 class="flex justify-center text-2xl font-bold mb-4">Cease Fire Report <span class="text-xs p-2 text-red">(Leave the lower part blank if you want*)</span> </h1>
+  <h1 class="flex justify-center text-2xl font-bold mb-4">Cease Fire Report <span class="text-xs p-2 text-red">(Leave the date field blank if you want all the data from inception to date*)</span> </h1>
 <% else %>
-  <h1 class="flex justify-center text-2xl font-bold mb-4">Status Report</h1>
+  <h1 class="flex justify-center text-2xl font-bold mb-4">Status Report <span class="text-xs p-2 text-red">(Leave the date field blank if you want all the data from inception to date*)</span> </h1>
 <% end %>
 <div class="p-2 w-full">
   <%= form_with url: cease_fire_report_path, method: :get, local: true do |f| %>


### PR DESCRIPTION
This pull request includes changes to improve the handling of ticket statuses, update the dashboard links, and correct a typo in a report view. The most important changes include updating the ticket filtering logic, modifying the dashboard links to use the first team name, and fixing a typo in the cease fire report view.

Improvements to ticket status handling:

* [`app/controllers/dashboards_controller.rb`](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L133-R135): Updated the `tickets` method to filter based on `sla_status` instead of `sla_target_response_deadline`.

Updates to dashboard links:

* [`app/views/dashboards/index.html.erb`](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L23-R52): Modified the dashboard links to use the first team's name instead of a single team variable.

Typo correction in report view:

* [`app/views/data_center/cease_fire_report.html.erb`](diffhunk://#diff-413ef0b0ccf29cf8ad0c2dae1da8e1b6bdfcd6656d3eede0a1db94ee98b1cc5eL2-R4): Corrected a typo in the cease fire report view to clarify the date field instructions.

Linting configuration update:

* [`.rubocop.yml`](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cL61-R61): Enabled the `Lint/DuplicateBranch` cop to enforce better code quality.