### PR TITLE
Remove unnecessary blank line in data_center_controller.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-bunsource 'https://rubygems.org'
+source 'https://rubygems.org'
 
 ruby '3.3.5'
 


### PR DESCRIPTION
This pull request includes a small change to the `Gemfile`. The change corrects a typo in the source URL by removing the incorrect 'bun' prefix.

* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fL1-R1): Corrected the source URL by removing the 'bun' prefix.