### PR TITLE
Fix pagination links to preserve filter parameter

### DIFF
--- a/app/views/project/show.html.erb
+++ b/app/views/project/show.html.erb
@@ -105,12 +105,11 @@
   <!-- Pagination Controls -->
   <div class="pagination">
     <% if @page > 1 %>
-      <%= link_to 'Previous', project_path(@project, page: @page - 1, **params.to_unsafe_h), class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
+      <%= link_to 'Previous', project_path(@project, page: @page - 1, filter: params[:filter]), class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
     <% end %>
     <span>Page <%= @page %> of <%= @total_pages %></span>
     <% if @page < @total_pages %>
-      <%= link_to 'Next', project_path(@project, page: @page + 1, **params.to_unsafe_h), class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
+      <%= link_to 'Next', project_path(@project, page: @page + 1, filter: params[:filter]), class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
     <% end %>
   </div>
 </div>
-


### PR DESCRIPTION
This pull request includes a small change to the pagination controls in the `project/show.html.erb` file. The change ensures that the filter parameter is preserved when navigating between pages.

* [`app/views/project/show.html.erb`](diffhunk://#diff-1e53ac6eb829f4c453e9553635c7157d5fb753acbc9c43ee272f9a5945577e13L108-L116): Updated the `link_to` helper to include the `filter` parameter in the pagination links.