### PR TITLE
Enhance cease fire report with client-specific details and improve CS…

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -318,7 +318,7 @@ class DataCenterController < ApplicationController
 
   def generate_start_of_day_csv(tickets)
     CSV.generate(headers: true) do |csv|
-      csv << ['Issue Key', 'Summary', 'Issue Type', 'Assignee', 'Reporter', 'Priority', 'Status', 'Resolution', 'Created', 'Updated', 'Due Date']
+      csv << ['Issue Key', 'Summary', 'Issue Type', 'Assignee', 'Reporter', 'Priority', 'Status', 'Created', 'Updated', 'Due Date']
       tickets.each do |ticket|
         csv << [
           ticket.unique_id,


### PR DESCRIPTION
This pull request includes a minor change to the `generate_start_of_day_csv` method in the `data_center_controller.rb` file. The change involves removing the 'Resolution' column from the CSV headers.

* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL321-R321): Removed the 'Resolution' column from the CSV headers in the `generate_start_of_day_csv` method.