### PR TITLE
Sod fix report

### DIFF
--- a/app/views/data_center/sod_report.html.erb
+++ b/app/views/data_center/sod_report.html.erb
@@ -7,6 +7,10 @@
         <%= label_tag :team_name, 'Select Department', class: "capitalize text-sm font-bold w-full align-middle pt-2" %>
         <%= select_tag :team_name, options_from_collection_for_select(Team.all, :name, :name, params[:team_name]), prompt: 'Choose a team', class: "border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full p-2" %>
       </div>
+      <div class="flex flex-col gap-2 w-full sm:w-1/2 md:w-1/3">
+        <%= label_tag :report_type, 'Report Type', class: "capitalize text-sm font-bold w-full align-middle pt-2" %>
+        <%= select_tag :report_type, options_for_select([['Start of Day', 'sod'], ['End of Day', 'eod']], params[:report_type]), prompt: 'Choose report type', class: "border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full p-2" %>
+      </div>
       <div class="flex flex-col gap-2 w-full sm:w-1/2 md:w-1/3 pt-9">
         <%= submit_tag 'Show Report', class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100 w-full sm:w-auto' %>
       </div>
@@ -14,10 +18,10 @@
   <% end %>
 
   <% if @tickets.any? %>
-    <div class="flex justify-end gap-2 container">
-    <%= link_to "Download CSV",
-                sod_report_path(format: :csv, team_name: params[:team_name]),
-                class: "bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100" %>
+    <div class="flex justify-end gap-2">
+      <%= link_to "Download CSV",
+                  sod_report_path(format: :csv, team_name: params[:team_name], report_type: params[:report_type]),
+                  class: "bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100" %>
     </div>
 
     <table class="min-w-full bg-white mt-4">

--- a/app/views/data_center/sod_report.html.erb
+++ b/app/views/data_center/sod_report.html.erb
@@ -1,17 +1,17 @@
 <div class="mx-auto mb-4 px-4 sm:px-6 lg:px-8 py-8">
-  <h2 class="text-xl font-bold mb-4 text-center capitalize">Start/End of Day Report</h2>
+  <h2 class="text-xl font-bold mb-4 text-center capitalize">Start & End of Day Report</h2>
 
   <%= form_with url: sod_report_path, method: :get, local: true do %>
     <div class="flex flex-wrap justify-center gap-2">
-      <div class="flex flex-col gap-2 w-full sm:w-1/2 md:w-1/3">
+      <div class="flex flex-col gap-2 w-full sm:w-1/3 md:w-1/3">
         <%= label_tag :team_name, 'Select Department', class: "capitalize text-sm font-bold w-full align-middle pt-2" %>
         <%= select_tag :team_name, options_from_collection_for_select(Team.all, :name, :name, params[:team_name]), prompt: 'Choose a team', class: "border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full p-2" %>
       </div>
-      <div class="flex flex-col gap-2 w-full sm:w-1/2 md:w-1/3">
+      <div class="flex flex-col gap-2 w-full sm:w-1/3 md:w-1/3">
         <%= label_tag :report_type, 'Report Type', class: "capitalize text-sm font-bold w-full align-middle pt-2" %>
         <%= select_tag :report_type, options_for_select([['Start of Day', 'sod'], ['End of Day', 'eod']], params[:report_type]), prompt: 'Choose report type', class: "border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full p-2" %>
       </div>
-      <div class="flex flex-col gap-2 w-full sm:w-1/2 md:w-1/3 pt-9">
+      <div class="flex flex-col gap-2 w-full sm:w-1/3 md:w-1/3 pt-9">
         <%= submit_tag 'Show Report', class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100 w-full sm:w-auto' %>
       </div>
     </div>


### PR DESCRIPTION
This pull request introduces changes to the `sod_report` method in the `DataCenterController` and updates the associated view to support generating both Start of Day (SOD) and End of Day (EOD) reports. The most important changes include adding a new parameter for report type, modifying the logic to filter tickets based on the report type, and updating the view to allow users to select the report type.

Changes to support SOD and EOD reports:

* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bR255-R276): Added a new parameter `report_type` and modified the ticket filtering logic to handle both SOD and EOD reports. EOD reports include tickets that changed to "outstanding statuses" within the last 24 hours or tickets that are not in those statuses, while SOD reports only include tickets that are not in the "outstanding statuses".
* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL277-R287): Updated the CSV filename generation to reflect the selected report type.

View updates:

* [`app/views/data_center/sod_report.html.erb`](diffhunk://#diff-98a12af047cee55bd85200b7572331fc617e9f993b60806dc2c26269a5bc53fbL2-R23): Updated the view to include a dropdown for selecting the report type (SOD or EOD) and adjusted the layout accordingly.