### PR TITLE
Issue with special characters

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -308,8 +308,8 @@ class DataCenterController < ApplicationController
               'Content']
       tickets.each do |ticket|
         csv << [
-          ticket.project.client.name,
-          ticket.unique_id,
+          ticket.project.client.name.gsub('–', '-'),
+          ticket.unique_id.gsub('–', '-'),
           ticket.issue,
           ticket.users.map(&:name).select(&:present?).join(', '),
           ticket.user.name,
@@ -362,7 +362,7 @@ class DataCenterController < ApplicationController
       tickets.each do |ticket|
         csv << [
           ticket.project.title,
-          ticket.unique_id,
+          ticket.unique_id.gsub('–', '-'),
           ticket.issue,
           ticket.users.map(&:name).select(&:present?).join(', '),
           ticket.user.name,
@@ -383,7 +383,7 @@ class DataCenterController < ApplicationController
       tickets.each do |ticket|
         csv << [
           ticket.subject,
-          ticket.unique_id,
+          ticket.unique_id.gsub('–', '-'),
           ticket.issue,
           ticket.statuses.first&.name || 'N/A',
           ticket.project.title,
@@ -405,7 +405,7 @@ class DataCenterController < ApplicationController
         sla_ticket = SlaTicket.find_by(ticket_id: ticket.id)
         csv << [
           ticket.subject,
-          ticket.unique_id,
+          ticket.unique_id.gsub('–', '-'),
           ticket.issue,
           ticket.statuses.first&.name || 'N/A',
           ticket.project.title,
@@ -432,7 +432,7 @@ class DataCenterController < ApplicationController
           csv << [
             user.name,
             ticket.project.title,
-            ticket.unique_id,
+            ticket.unique_id.gsub('–', '-'),
             ticket.subject,
             ticket.statuses.first&.name || 'N/A',
             sla_ticket&.sla_target_response_deadline || 'N/A',
@@ -451,7 +451,7 @@ class DataCenterController < ApplicationController
       tickets.each do |ticket|
         latest_issue = Issue.where(ticket_id: ticket.id).order(updated_at: :desc).first
         csv << [
-          ticket.unique_id,
+          ticket.unique_id.gsub('–', '-'),
           ticket.subject,
           ticket.issue,
           ticket.users.map(&:name).select(&:present?).join(', '),


### PR DESCRIPTION
This pull request includes changes to the `app/controllers/data_center_controller.rb` file to ensure that the `unique_id` and `client.name` fields in CSV exports replace the en dash character (–) with a standard hyphen (-). This change is applied across multiple CSV generation methods to maintain consistency and avoid issues with data processing.

CSV generation updates:

* [`generate_orm_report_csv`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL311-R312): Replaced en dash with hyphen for `ticket.project.client.name` and `ticket.unique_id`.
* [`generate_project_report_csv`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL365-R365): Replaced en dash with hyphen for `ticket.unique_id`.
* [`generate_csv`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL386-R386): Replaced en dash with hyphen for `ticket.unique_id`.
* [`generate_breach_details_csv`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL408-R408): Replaced en dash with hyphen for `ticket.unique_id`.
* [`generate_user_csv`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL435-R435): Replaced en dash with hyphen for `ticket.unique_id`.
* [`generate_start_of_day_csv`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL454-R454): Replaced en dash with hyphen for `ticket.unique_id`.