### PR TITLE
Add graph on workload report

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -120,7 +120,6 @@ class DataCenterController < ApplicationController
       @tickets_chart_data = @organized_tickets.transform_keys { |id| User.find(id).name }
       @tickets_chart_data = @tickets_chart_data.transform_values { |data| data[:total] }
 
-
       respond_to do |format|
         format.html # Default view
         team_name = @team.name

--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -118,6 +118,8 @@ class DataCenterController < ApplicationController
 
       # Prepare data for the pie chart
       @tickets_chart_data = @organized_tickets.transform_keys { |id| User.find(id).name }
+      @tickets_chart_data = @tickets_chart_data.transform_values { |data| data[:total] }
+
 
       respond_to do |format|
         format.html # Default view

--- a/app/views/data_center/project_report.html.erb
+++ b/app/views/data_center/project_report.html.erb
@@ -1,4 +1,4 @@
-<h1 class="flex justify-center text-2xl font-bold mb-4">Project Report</h1>
+<h1 class="flex justify-center text-2xl font-bold mb-4">Workload Report</h1>
 <div class="p-2 w-full">
   <%= form_with url: project_report_path, method: :get, local: true do %>
     <div class="flex flex-wrap justify-center gap-2">
@@ -34,6 +34,7 @@
     <div class="flex justify-center w-full my-6">
       <%= pie_chart @tickets_chart_data, height: "400px", library: { title: { text: "Tickets by User" } } %>
     </div>
+
 
     <table class="table-auto w-full border-collapse border border-gray-300">
       <thead>


### PR DESCRIPTION
This pull request includes updates to the `project_report` method in the `DataCenterController` and changes to the `project_report.html.erb` view to improve the presentation and accuracy of the project report data.

Updates to `project_report` method:

* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bR121): The `@tickets_chart_data` is now transformed to only include the total number of tickets per user.

Changes to `project_report.html.erb` view:

* [`app/views/data_center/project_report.html.erb`](diffhunk://#diff-14f4fa09e361a49b230054ee86a377aa4183fd434735213a31085e85e36c9c05L1-R1): The title of the report has been changed from "Project Report" to "Workload Report".
* [`app/views/data_center/project_report.html.erb`](diffhunk://#diff-14f4fa09e361a49b230054ee86a377aa4183fd434735213a31085e85e36c9c05R38): Added a blank line for better readability between the pie chart and the table.