### PR TITLE
Add tickets per project chart and display top 5 users by tickets

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -148,7 +148,6 @@ class DataCenterController < ApplicationController
       @tickets_chart_data = @tickets_chart_data.transform_values { |data| data[:total] }
       @tickets_per_project = @tickets.group('projects.title').count
 
-
       respond_to do |format|
         format.html # Default view
         team_name = @team.name

--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -146,6 +146,8 @@ class DataCenterController < ApplicationController
       # Prepare data for the pie chart
       @tickets_chart_data = @organized_tickets.transform_keys { |id| User.find(id).name }
       @tickets_chart_data = @tickets_chart_data.transform_values { |data| data[:total] }
+      @tickets_per_project = @tickets.group('projects.title').count
+
 
       respond_to do |format|
         format.html # Default view

--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -166,13 +166,15 @@ class DataCenterController < ApplicationController
     @team = Team.find(params[:team_id])
     if params[:user_id]
       @user = User.find(params[:user_id])
-      @tickets = Ticket.joins(:statuses, :taggings)
+      @tickets = Ticket.joins(:statuses, :taggings, :project)
         .where.not(statuses: { name: %w[Resolved Closed Declined] })
         .where(taggings: { user_id: @user.id })
+        .order('projects.title')
     else
-      @tickets_by_user = Ticket.joins(:statuses, :taggings)
+      @tickets_by_user = Ticket.joins(:statuses, :taggings, :project)
         .where.not(statuses: { name: %w[Resolved Closed Declined] })
         .where(taggings: { user_id: @team.users.pluck(:id) })
+        .order('projects.title')
         .group_by(&:user)
     end
   end

--- a/app/views/data_center/assigned_tickets.html.erb
+++ b/app/views/data_center/assigned_tickets.html.erb
@@ -1,12 +1,40 @@
 <h1 class="flex justify-center text-2xl font-bold mb-4">Assigned Tickets for <%= @user.name %></h1>
 
+
+
 <div class="mx-auto mb-4 px-4 sm:px-6 lg:px-8 py-8">
+
+  <!-- New table to show project names and ticket counts -->
+  <table class="border-collapse border border-gray-300 w-full mb-4">
+    <thead>
+    <tr>
+      <th scope="col" class="border border-gray-300 px-4 py-2">Project Name</th>
+      <th scope="col" class="border border-gray-300 px-4 py-2">Number of Tickets</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @tickets.group_by { |ticket| ticket.project.title }
+               .sort_by { |_, tickets| -tickets.count }
+               .each do |project_title, tickets| %>
+      <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">
+        <td class="px-4 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white capitalize">
+          <%= project_title %>
+        </td>
+        <td class="px-4 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+          <%= tickets.count %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+
+
     <table class="border-collapse border border-gray-300 w-full mb-4">
       <thead>
       <tr>
         <th scope="col" class="border border-gray-300 px-4 py-2">Date of Creation</th>
-        <th scope="col" class="border border-gray-300 px-4 py-2">Ticket ID</th>
         <th scope="col" class="border border-gray-300 px-4 py-2">Name of the Project</th>
+        <th scope="col" class="border border-gray-300 px-4 py-2">Ticket ID</th>
         <th scope="col" class="border border-gray-300 px-4 py-2">Issue</th>
         <th scope="col" class="border border-gray-300 px-4 py-2">Priority</th>
         <th scope="col" class="border border-gray-300 px-4 py-2">Summary</th>

--- a/app/views/data_center/project_report.html.erb
+++ b/app/views/data_center/project_report.html.erb
@@ -31,9 +31,36 @@
       <%= link_to 'Download CSV Report', project_report_path(format: :csv, team_id: @team.id), class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100 w-full sm:w-auto' %>
     </div>
 
-    <div class="flex justify-center w-full my-6">
-      <%= pie_chart @tickets_chart_data, height: "400px", library: { title: { text: "Tickets by User" } } %>
+    <div class="flex justify-center w-full my-6 gap-10">
+      <div class="flex justify-center gap-10">
+        <div>
+        <%= pie_chart @tickets_chart_data, height: "400px", library: { title: { text: "Tickets by User" } } %>
+        </div>
+        <div>
+          <h3 class="text-lg font-bold mb-2">Top 5 Users by Tickets</h3>
+          <ul>
+            <% @tickets_chart_data.sort_by { |_, count| -count }.first(5).each do |user, count| %>
+              <li class="mb-1 capitalize"><%= user %>: <%= count %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+
+      <div class="flex justify-center gap-10">
+        <div>
+          <%= pie_chart @tickets_per_project, height: "400px", library: { title: { text: "Tickets per Project" } } %>
+        </div>
+        <div>
+          <h3 class="text-lg font-bold mb-2">Project Ticket Counts</h3>
+          <ul>
+            <% @tickets_per_project.sort_by { |_, count| -count }.each do |project, count| %>
+              <li class="mb-1 capitalize"><%= project %>: <%= count %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
     </div>
+
 
 
     <table class="table-auto w-full border-collapse border border-gray-300">


### PR DESCRIPTION
This pull request includes changes to enhance the project report feature in the `data_center` module by adding new data visualizations and improving the layout of the report page. The most important changes include adding a new pie chart and corresponding data for tickets per project, and updating the HTML view to display these new elements.

Enhancements to project report feature:

* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bR149-R150): Added a new instance variable `@tickets_per_project` to group and count tickets by project.

Updates to HTML view:

* [`app/views/data_center/project_report.html.erb`](diffhunk://#diff-14f4fa09e361a49b230054ee86a377aa4183fd434735213a31085e85e36c9c05L34-R63): Modified the layout to include two new sections: a pie chart for tickets per project and a list of project ticket counts. Also added a gap between sections for better visual separation.