### PR TITLE
Refine ticket query to filter by client ID for closed and resolved ti…

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -208,10 +208,11 @@ class DataCenterController < ApplicationController
 
       # Handle days filter
       if days.positive?
-        closed_resolved_tickets = Ticket.joins(project: :client)
+        closed_resolved_tickets = @tickets.joins(project: :client)
           .joins(:statuses)
           .where(statuses: { name: %w[Closed Resolved Declined] })
           .where('tickets.created_at >= ?', days.days.ago)
+          .where(projects: { client_id: params[:client_id] })
         @tickets = @tickets.or(closed_resolved_tickets)
       end
 


### PR DESCRIPTION
This pull request includes a change to the `orm_report` method in the `data_center_controller.rb` file. The change modifies the query to filter tickets by client ID.

* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL211-R215): Updated the query in the `orm_report` method to filter tickets by `client_id` using the `params[:client_id]` parameter.