### PR TITLE
Feature/dashboard addition

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -53,6 +53,20 @@ class DashboardsController < ApplicationController
         .joins(:sla_tickets)
         .where(sla_tickets: { sla_resolution_deadline: 'Breached' })
         .count
+      resolution_breached_open_last_30_days = tickets_last_30_days
+        .joins(:sla_tickets)
+        .where(sla_tickets: { sla_resolution_deadline: 'Breached' })
+        .joins('LEFT JOIN add_statuses ON add_statuses.ticket_id = tickets.id')
+        .joins('LEFT JOIN statuses ON statuses.id = add_statuses.status_id')
+        .where.not(statuses: { name: %w[Closed Resolved] })
+        .count
+      resolution_breached_closed_last_30_days = tickets_last_30_days
+        .joins(:sla_tickets)
+        .where(sla_tickets: { sla_resolution_deadline: 'Breached' })
+        .joins('LEFT JOIN add_statuses ON add_statuses.ticket_id = tickets.id')
+        .joins('LEFT JOIN statuses ON statuses.id = add_statuses.status_id')
+        .where(statuses: { name: %w[Closed Resolved] })
+        .count
       not_resolution_breached_tickets_last_30_days = tickets_last_30_days
         .joins(:sla_tickets)
         .where(sla_tickets: { sla_resolution_deadline: ['Not Breached', nil] })
@@ -95,6 +109,8 @@ class DashboardsController < ApplicationController
         response_breached_tickets_open_last_30_days: response_breached_tickets_open_last_30_days,
         not_response_breached_tickets_last_30_days: not_response_breached_tickets_last_30_days,
         resolution_breached_tickets_last_30_days: resolution_breached_tickets_last_30_days,
+        resolution_breached_open_last_30_days: resolution_breached_open_last_30_days,
+        resolution_breached_closed_last_30_days: resolution_breached_closed_last_30_days,
         not_resolution_breached_tickets_last_30_days: not_resolution_breached_tickets_last_30_days,
         breached_tickets_per_assignee: breached_tickets_per_assignee,
         breached_resolution_tickets_per_project: breached_resolution_tickets_per_project,

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -144,10 +144,30 @@ class DashboardsController < ApplicationController
         @tickets = @tickets.where(sla_tickets: { sla_status: ['Not Breached', nil] })
       when 'target_repair_time_breached'
         @tickets = @tickets.where(sla_tickets: { sla_target_response_deadline: 'Breached' })
+      when 'target_repair_time_breached_open'
+        @tickets = @tickets.joins('LEFT JOIN add_statuses ON add_statuses.ticket_id = tickets.id')
+          .joins('LEFT JOIN statuses ON statuses.id = add_statuses.status_id')
+          .where(sla_tickets: { sla_target_response_deadline: 'Breached' })
+          .where.not(statuses: { name: %w[Closed Resolved] })
+      when 'target_repair_time_breached_closed'
+        @tickets = @tickets.joins('LEFT JOIN add_statuses ON add_statuses.ticket_id = tickets.id')
+          .joins('LEFT JOIN statuses ON statuses.id = add_statuses.status_id')
+          .where(sla_tickets: { sla_target_response_deadline: 'Breached' })
+          .where(statuses: { name: %w[Closed Resolved] })
       when 'target_repair_time_not_breached'
         @tickets = @tickets.where(sla_tickets: { sla_target_response_deadline: ['Not Breached', nil] })
       when 'target_resolution_time_breached'
         @tickets = @tickets.where(sla_tickets: { sla_resolution_deadline: 'Breached' })
+      when 'target_resolution_time_breached_open'
+        @tickets = @tickets.joins('LEFT JOIN add_statuses ON add_statuses.ticket_id = tickets.id')
+          .joins('LEFT JOIN statuses ON statuses.id = add_statuses.status_id')
+          .where(sla_tickets: { sla_resolution_deadline: 'Breached' })
+          .where.not(statuses: { name: %w[Closed Resolved] })
+      when 'target_resolution_time_breached_closed'
+        @tickets = @tickets.joins('LEFT JOIN add_statuses ON add_statuses.ticket_id = tickets.id')
+          .joins('LEFT JOIN statuses ON statuses.id = add_statuses.status_id')
+          .where(sla_tickets: { sla_resolution_deadline: 'Breached' })
+          .where(statuses: { name: %w[Closed Resolved] })
       when 'target_resolution_time_not_breached'
         @tickets = @tickets.where(sla_tickets: { sla_resolution_deadline: ['Not Breached', nil] })
       when 'total_tickets_last_30_days'

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -31,6 +31,20 @@ class DashboardsController < ApplicationController
         .joins(:sla_tickets)
         .where(sla_tickets: { sla_target_response_deadline: 'Breached' })
         .count
+      response_breached_tickets_closed_last_30_days = tickets_last_30_days
+        .joins(:sla_tickets)
+        .joins('LEFT JOIN add_statuses ON add_statuses.ticket_id = tickets.id')
+        .joins('LEFT JOIN statuses ON statuses.id = add_statuses.status_id')
+        .where(sla_tickets: { sla_target_response_deadline: 'Breached' })
+        .where(statuses: { name: %w[Closed Resolved] })
+        .count
+      response_breached_tickets_open_last_30_days = tickets_last_30_days
+        .joins(:sla_tickets)
+        .joins('LEFT JOIN add_statuses ON add_statuses.ticket_id = tickets.id')
+        .joins('LEFT JOIN statuses ON statuses.id = add_statuses.status_id')
+        .where(sla_tickets: { sla_target_response_deadline: 'Breached' })
+        .where.not(statuses: { name: %w[Closed Resolved] })
+        .count
       not_response_breached_tickets_last_30_days = tickets_last_30_days
         .joins(:sla_tickets)
         .where(sla_tickets: { sla_target_response_deadline: ['Not Breached', nil] })
@@ -77,6 +91,8 @@ class DashboardsController < ApplicationController
         breached_tickets_last_30_days: breached_tickets_last_30_days,
         not_breached_tickets_last_30_days: not_breached_tickets_last_30_days,
         response_breached_tickets_last_30_days: response_breached_tickets_last_30_days,
+        response_breached_tickets_closed_last_30_days: response_breached_tickets_closed_last_30_days,
+        response_breached_tickets_open_last_30_days: response_breached_tickets_open_last_30_days,
         not_response_breached_tickets_last_30_days: not_response_breached_tickets_last_30_days,
         resolution_breached_tickets_last_30_days: resolution_breached_tickets_last_30_days,
         not_resolution_breached_tickets_last_30_days: not_resolution_breached_tickets_last_30_days,

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -72,9 +72,9 @@
     </div>
 
     <div class="bg-white p-4 shadow-md rounded-lg">
-      <h2 class="text-lg font-semibold mb-3 text-center">Target Resolution Time (Not Breached)</h2>
-      <div id="resolutionTimeChart">
-        <%= pie_chart [["Breached", @stats[:resolution_breached_tickets_last_30_days]], ["Not Breached", @stats[:not_resolution_breached_tickets_last_30_days]]], colors: %w[#ff0000 #0000ff]%>
+      <h2 class="text-lg font-semibold mb-3 text-center">Target Resolution Time Breached (Closed vs Open)</h2>
+      <div id="resolutionOpenClosedTimeChart">
+        <%= pie_chart [["Closed", @stats[:resolution_breached_tickets_last_30_days]], ["Open", @stats[:not_resolution_breached_tickets_last_30_days]]], colors: %w[#ff0000 #0000ff]%>
       </div>
     </div>
   </div>
@@ -254,6 +254,12 @@
         new Chartkick.PieChart("responseOpenClosedTimeChart", [
           [`Closed (${data.response_breached_tickets_closed_last_30_days})`, data.response_breached_tickets_closed_last_30_days],
           [`Open (${data.response_breached_tickets_open_last_30_days})`, data.response_breached_tickets_open_last_30_days]
+        ], { colors: ["#36a2eb", "#ff0000"] });
+
+        document.getElementById("resolutionOpenClosedTimeChart").innerHTML = "";
+        new Chartkick.PieChart("rresolutionOpenClosedTimeChart", [
+          [`Closed (${data.resolution_breached_closed_last_30_days})`, data.resolution_breached_closed_last_30_days],
+          [`Open (${data.resolution_breached_open_last_30_days})`, data.resolution_breached_open_last_30_days]
         ], { colors: ["#ff0000", "#36a2eb"] });
 
         document.getElementById("resolutionTimeChart").innerHTML = "";

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -44,11 +44,11 @@
     <a href="#" class="stat-card-link" data-type="target_repair_time_breached_closed" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached_closed')">
       <%= render 'dashboards/stat_card', title: "Target Repair Time Breached - (Closed)", value: @stats[:response_breached_tickets_closed_last_30_days], id: "target_repair_time_breached_closed", class: 'col-span-1'  %>
     </a>
-    <a href="#" class="stat-card-link" data-type="target_resolution_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached')">
-      <%= render 'dashboards/stat_card', title: "Target Resolution Time Breached - (Open)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
+    <a href="#" class="stat-card-link" data-type="target_resolution_time_breached_open" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached_open')">
+      <%= render 'dashboards/stat_card', title: "Target Resolution Time Breached - (Open)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached_open", class: 'col-span-1'  %>
     </a>
-    <a href="#" class="stat-card-link" data-type="target_resolution_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached')">
-      <%= render 'dashboards/stat_card', title: "Target Resolution Time Breached - (Closed)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
+    <a href="#" class="stat-card-link" data-type="target_resolution_time_breached_closed" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached_open')">
+      <%= render 'dashboards/stat_card', title: "Target Resolution Time Breached - (Closed)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached_closed", class: 'col-span-1'  %>
     </a>
       <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
           <a href="#" class="stat-card-link" data-type="total_tickets_last_30_days" onclick="fetchTicketDetails('<%= @selected_team %>', 'total_tickets_last_30_days')">
@@ -255,8 +255,8 @@
         document.getElementById("target_resolution_time_not_breached").innerText = data.not_resolution_breached_tickets_last_30_days;
         document.getElementById("target_repair_time_breached_open").innerText = data.response_breached_tickets_open_last_30_days;
         document.getElementById("target_repair_time_breached_closed").innerText = data.response_breached_tickets_closed_last_30_days;
-        document.getElementById("target_resolution_time_breached").innerText = data.resolution_breached_tickets_last_30_days;
-        document.getElementById("target_resolution_time_breached").innerText = data.resolution_breached_tickets_last_30_days;
+        document.getElementById("target_resolution_time_breached_open").innerText = data.resolution_breached_open_last_30_days;
+        document.getElementById("target_resolution_time_breached_closed").innerText = data.resolution_breached_closed_last_30_days;
 
         // Refresh charts
         document.getElementById("responseTimeChart").innerHTML = "";

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -38,6 +38,18 @@
     <a href="#" class="stat-card-link" data-type="target_resolution_time_not_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_not_breached')">
       <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached", class: 'col-span-1'  %>
     </a>
+     <a href="#" class="stat-card-link" data-type="target_repair_time_breached_open" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached_open')">
+      <%= render 'dashboards/stat_card', title: "Target Repair Time Breached - (Open)", value: @stats[:response_breached_tickets_open_last_30_days], id: "target_repair_time_breached_open", class: 'col-span-1'  %>
+    </a>
+    <a href="#" class="stat-card-link" data-type="target_repair_time_breached_closed" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached_closed')">
+      <%= render 'dashboards/stat_card', title: "Target Repair Time Breached - (Closed)", value: @stats[:response_breached_tickets_closed_last_30_days], id: "target_repair_time_breached_closed", class: 'col-span-1'  %>
+    </a>
+    <a href="#" class="stat-card-link" data-type="target_resolution_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached')">
+      <%= render 'dashboards/stat_card', title: "Target Resolution Time Breached - (Open)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
+    </a>
+    <a href="#" class="stat-card-link" data-type="target_resolution_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached')">
+      <%= render 'dashboards/stat_card', title: "Target Resolution Time Breached - (Closed)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
+    </a>
       <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
           <a href="#" class="stat-card-link" data-type="total_tickets_last_30_days" onclick="fetchTicketDetails('<%= @selected_team %>', 'total_tickets_last_30_days')">
             <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days"%>
@@ -241,6 +253,10 @@
         document.getElementById("target_repair_time_not_breached").innerText = data.not_response_breached_tickets_last_30_days;
         document.getElementById("target_resolution_time_breached").innerText = data.resolution_breached_tickets_last_30_days;
         document.getElementById("target_resolution_time_not_breached").innerText = data.not_resolution_breached_tickets_last_30_days;
+        document.getElementById("target_repair_time_breached_open").innerText = data.response_breached_tickets_open_last_30_days;
+        document.getElementById("target_repair_time_breached_closed").innerText = data.response_breached_tickets_closed_last_30_days;
+        document.getElementById("target_resolution_time_breached").innerText = data.resolution_breached_tickets_last_30_days;
+        document.getElementById("target_resolution_time_breached").innerText = data.resolution_breached_tickets_last_30_days;
 
         // Refresh charts
         document.getElementById("responseTimeChart").innerHTML = "";

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -63,6 +63,23 @@
   </div>
 
   <!-- Charts Section -->
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div class="bg-white p-4 shadow-md rounded-lg">
+      <h2 class="text-lg font-semibold mb-3 text-center">Target Repair Time Breached (Closed vs Open)</h2>
+      <div id="responseOpenClosedTimeChart">
+        <%= pie_chart [["Closed", @stats[:response_breached_tickets_closed_last_30_days]], ["Open", @stats[:response_breached_tickets_open_last_30_days]]], colors: %w[#ff0000 #0000ff] %>
+      </div>
+    </div>
+
+    <div class="bg-white p-4 shadow-md rounded-lg">
+      <h2 class="text-lg font-semibold mb-3 text-center">Target Resolution Time (Not Breached)</h2>
+      <div id="resolutionTimeChart">
+        <%= pie_chart [["Breached", @stats[:resolution_breached_tickets_last_30_days]], ["Not Breached", @stats[:not_resolution_breached_tickets_last_30_days]]], colors: %w[#ff0000 #0000ff]%>
+      </div>
+    </div>
+  </div>
+
+  <!-- Charts Section -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-10">
     <div class="bg-white p-4 shadow-md rounded-lg">
       <h2 class="text-lg font-semibold mb-3 text-center">Target Repair Time Assignees (Breached)</h2>
@@ -230,6 +247,13 @@
         new Chartkick.PieChart("responseTimeChart", [
           [`Breached (${data.response_breached_tickets_last_30_days})`, data.response_breached_tickets_last_30_days],
           [`Not Breached (${data.not_response_breached_tickets_last_30_days})`, data.not_response_breached_tickets_last_30_days]
+        ], { colors: ["#ff0000", "#36a2eb"] });
+
+        // Refresh charts
+        document.getElementById("responseOpenClosedTimeChart").innerHTML = "";
+        new Chartkick.PieChart("responseOpenClosedTimeChart", [
+          [`Closed (${data.response_breached_tickets_closed_last_30_days})`, data.response_breached_tickets_closed_last_30_days],
+          [`Open (${data.response_breached_tickets_open_last_30_days})`, data.response_breached_tickets_open_last_30_days]
         ], { colors: ["#ff0000", "#36a2eb"] });
 
         document.getElementById("resolutionTimeChart").innerHTML = "";


### PR DESCRIPTION
This pull request includes several changes to the `dashboards_controller.rb` and `index.html.erb` files to enhance the tracking and display of SLA breached tickets, categorized by their status (open or closed). The most important changes include the addition of new query conditions, updates to the view to display new statistics, and the inclusion of new charts for better visualization.

Enhancements to `dashboards_controller.rb`:

* Added conditions to fetch counts of response and resolution breached tickets that are either open or closed in the `fetch_stats` method. [[1]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5R34-R47) [[2]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5R56-R69)
* Updated the `tickets` method to include new filters for breached tickets categorized by open or closed status.

Updates to `index.html.erb`:

* Added new stat cards to display counts of response and resolution breached tickets that are either open or closed.
* Introduced new pie charts to visualize the distribution of open vs closed tickets for both response and resolution breaches.
* Updated JavaScript to refresh the new charts with the latest data. [[1]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60R256-R259) [[2]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60R268-R280)