### PR TITLE
Refine ticket query to filter by client ID for closed and resolved ti…

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -208,7 +208,7 @@ class DataCenterController < ApplicationController
 
       # Handle days filter
       if days.positive?
-        closed_resolved_tickets = @tickets.joins(project: :client)
+        closed_resolved_tickets = Ticket.joins(project: :client)
           .joins(:statuses)
           .where(statuses: { name: %w[Closed Resolved Declined] })
           .where('tickets.created_at >= ?', days.days.ago)

--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -365,8 +365,8 @@ class DataCenterController < ApplicationController
       end
 
       csv << []
-      csv << ['Client Name', 'Ticket ID', 'Issue Type', 'Assignee', 'Reporter', 'Severity', 'Status', 'Created At', 'Updated At', 'Summary',
-              'Content', 'Due Date']
+      csv << ['Client Name', 'Ticket ID', 'Issue Type', 'Assignee', 'Reporter', 'Severity', 'Status', 'Created At', 'Updated At',
+              'Status Updated At', 'Last Comment Updated At', 'Summary', 'Content', 'Due Date']
       tickets.each do |ticket|
         csv << [
           ticket.project.client.name.gsub('–', '-'),
@@ -378,6 +378,8 @@ class DataCenterController < ApplicationController
           ticket.statuses.first&.name || 'N/A',
           ticket.created_at.strftime('%d-%b-%Y'),
           ticket.updated_at.strftime('%d-%b-%Y'),
+          ticket.add_statuses.order(updated_at: :desc).first&.updated_at&.strftime('%d-%b-%Y %H:%M:%S') || 'N/A',
+          ticket.issues.order(updated_at: :desc).first&.updated_at&.strftime('%H:%M of %d-%b-%Y') || 'N/A',
           ticket.subject,
           ticket.content.to_plain_text.truncate(3000),
           ticket.due_date&.strftime('%d-%b-%Y') || 'N/A'
@@ -399,8 +401,8 @@ class DataCenterController < ApplicationController
       end
 
       csv << []
-      csv << ['Client Name', 'Ticket ID', 'Issue Type', 'Assignee', 'Reporter', 'Severity', 'Status', 'Created At', 'Status Updated At', 'Summary',
-              'Content', 'Due Date']
+      csv << ['Client Name', 'Ticket ID', 'Issue Type', 'Assignee', 'Reporter', 'Severity', 'Status', 'Created At',
+              'Status Updated At', 'Summary', 'Last Comment Updated At', 'Due Date']
       tickets.each do |ticket|
         csv << [
           ticket.project.client.name.gsub('–', '-'),
@@ -413,7 +415,7 @@ class DataCenterController < ApplicationController
           ticket.created_at.strftime('%d-%b-%Y'),
           ticket.add_statuses.order(updated_at: :desc).first&.updated_at&.strftime('%d-%b-%Y %H:%M:%S') || 'N/A',
           ticket.subject,
-          ticket.content.to_plain_text.truncate(3000),
+          ticket.issues.order(updated_at: :desc).first&.updated_at&.strftime('%H:%M of %d-%b-%Y') || 'N/A',
           ticket.due_date&.strftime('%d-%b-%Y') || 'N/A'
         ]
       end

--- a/app/views/data_center/orm_report.html.erb
+++ b/app/views/data_center/orm_report.html.erb
@@ -93,6 +93,7 @@
         <th class="border border-black px-4 py-2">Created at</th>
         <th class="border border-black px-4 py-2">updated at</th>
         <th class="border border-black px-4 py-2">Status Updated at</th>
+        <th class="border border-black px-4 py-2">Last Comment Updated at</th>
         <th class="border border-black px-4 py-2">Summary</th>
         <th class="border border-black px-4 py-2">Content</th>
         <th class="border border-black px-4 py-2">Due Date</th>
@@ -141,8 +142,8 @@
           <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.statuses.first&.name || 'N/A' %></td>
           <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.created_at.strftime("%d-%b-%Y") %></td>
           <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.updated_at.strftime("%d-%b-%Y") %></td>
-          <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.add_statuses.order(updated_at: :desc).first&.updated_at&.strftime('%d-%b-%Y %H:%M:%S') || 'N/A' %></td>
-
+          <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.add_statuses.order(updated_at: :desc).first&.updated_at&.strftime('%H:%M of %d-%b-%Y') || 'N/A' %></td>
+          <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.issues.order(updated_at: :desc).first&.updated_at&.strftime('%H:%M of %d-%b-%Y') || 'N/A' %></td>
           <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.subject %></td>
           <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.content.to_plain_text.truncate(3000) %></td>
           <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.due_date&.strftime("%d-%b-%Y") || 'N/A' %></td>

--- a/app/views/data_center/orm_team_report.html.erb
+++ b/app/views/data_center/orm_team_report.html.erb
@@ -86,7 +86,7 @@
         <th class="border border-black px-4 py-2">Created at</th>
         <th class="border border-black px-4 py-2">updated at</th>
         <th class="border border-black px-4 py-2">Summary</th>
-        <th class="border border-black px-4 py-2">Content</th>
+        <th class="border border-black px-4 py-2">Last Comment Updated At</th>
         <th class="border border-black px-4 py-2">Due Date</th>
       </tr>
       </thead>
@@ -132,7 +132,7 @@
           <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.created_at.strftime("%d-%b-%Y") %></td>
           <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.add_statuses.order(updated_at: :desc).first&.updated_at&.strftime('%d-%b-%Y %H:%M:%S') || 'N/A' %></td>
           <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.subject %></td>
-          <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.content.to_plain_text.truncate(3000) %></td>
+          <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.issues.order(updated_at: :desc).first&.updated_at&.strftime('%d-%b-%Y %H:%M:%S') || 'N/A' %></td>
           <td class="border border-black dark:border-slate-100 px-4 py-2"><%= ticket.due_date&.strftime("%d-%b-%Y") || 'N/A' %></td>
         </tr>
       <% end %>


### PR DESCRIPTION
This pull request includes a small change to the `orm_report` method in the `data_center_controller.rb` file. The change modifies the query to use the `Ticket` model directly instead of an instance variable.

* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL211-R211): Changed `closed_resolved_tickets` query to use `Ticket` model directly.