### PR TITLE
Remove require kaminari

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,18 +198,6 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.8.1)
-    kaminari (1.2.2)
-      activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.2.2)
-      kaminari-activerecord (= 1.2.2)
-      kaminari-core (= 1.2.2)
-    kaminari-actionview (1.2.2)
-      actionview
-      kaminari-core (= 1.2.2)
-    kaminari-activerecord (1.2.2)
-      activerecord
-      kaminari-core (= 1.2.2)
-    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     launchy (3.0.1)
       addressable (~> 2.8)
@@ -466,7 +454,6 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
-  kaminari (~> 1.2)
   letter_opener
   mini_magick (~> 4.13)
   ostruct

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,6 @@ require_relative "boot"
 
 require "rails/all"
 require 'paper_trail'
-require 'kaminari'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
This pull request includes a small change to the `config/application.rb` file. The change removes the unnecessary inclusion of the `kaminari` gem.

* [`config/application.rb`](diffhunk://#diff-c1fd91cb1911a0512578b99f657554526f3e1421decdb9e908712beab57e10f9L5): Removed the `require 'kaminari'` line as it is no longer needed.