### PR TITLE
Sort project tickets by creation date in report and clean up topbar HTML

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -494,7 +494,7 @@ class DataCenterController < ApplicationController
       workbook.add_worksheet(name: project_title) do |sheet|
         sheet.add_row ['Ticket ID', 'Project Name', 'Severity', 'Summary', 'Issue Type', 'Status', 'Assignee To', 'Reporter', 'Details', 'Created', 'Status Updated At',
                        'Last Comment Updated At', 'Due Date']
-        project_tickets.each do |ticket|
+        project_tickets.sort_by { |ticket| -ticket.created_at.to_i }.each do |ticket|
           status = ticket.statuses.first&.name || 'N/A'
           row_style = styles[status] || nil
 

--- a/app/views/layouts/_topbar.html.erb
+++ b/app/views/layouts/_topbar.html.erb
@@ -58,7 +58,7 @@
     <div class="relative mx-auto text-gray-600">
       <%= form_with url: project_index_path, method: :get, class: 'relative flex items-center' do |f| %>
         <%= f.text_field :query, placeholder: "Search", class: "border border-gray-300 h-10 w-96 px-5 pr-10 rounded-lg text-sm placeholder-current focus:outline-none dark:bg-gray-500 dark:border-gray-50 dark:text-gray-200", id: "searchInput" %>
-        
+
         <!-- Clear Button (X) -->
         <button type="button" id="clearSearch" class="absolute right-10 top-0 mt-2 mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-200 dark:hover:text-white hidden">
           &times;


### PR DESCRIPTION
This pull request includes changes to the `app/controllers/data_center_controller.rb` file to improve the sorting of tickets in the generated XLSX file.

Changes to ticket sorting:

* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL497-R497): Modified the `generate_xlsx` method to sort `project_tickets` by creation date in descending order before adding them to the worksheet.