### PR TITLE
Feature/no sla graph

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -53,6 +53,10 @@ class DashboardsController < ApplicationController
         .joins(:sla_tickets)
         .where(sla_tickets: { sla_resolution_deadline: 'Breached' })
         .count
+      no_sla_tickets_last_30_days = tickets_last_30_days
+        .joins(:sla_tickets)
+        .where(sla_tickets: { sla_resolution_deadline: 'NO SLA' })
+        .count
       resolution_breached_open_last_30_days = tickets_last_30_days
         .joins(:sla_tickets)
         .where(sla_tickets: { sla_resolution_deadline: 'Breached' })
@@ -102,6 +106,7 @@ class DashboardsController < ApplicationController
 
       stats = {
         total_tickets_last_30_days: total_tickets_last_30_days,
+        no_sla_tickets_last_30_days: no_sla_tickets_last_30_days,
         breached_tickets_last_30_days: breached_tickets_last_30_days,
         not_breached_tickets_last_30_days: not_breached_tickets_last_30_days,
         response_breached_tickets_last_30_days: response_breached_tickets_last_30_days,
@@ -158,6 +163,8 @@ class DashboardsController < ApplicationController
         @tickets = @tickets.where(sla_tickets: { sla_target_response_deadline: ['Not Breached', nil] })
       when 'target_resolution_time_breached'
         @tickets = @tickets.where(sla_tickets: { sla_resolution_deadline: 'Breached' })
+      when 'no_sla_population'
+        @tickets = @tickets.where(sla_tickets: { sla_resolution_deadline: 'NO SLA' })
       when 'target_resolution_time_breached_open'
         @tickets = @tickets.joins('LEFT JOIN add_statuses ON add_statuses.ticket_id = tickets.id')
           .joins('LEFT JOIN statuses ON statuses.id = add_statuses.status_id')

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -35,40 +35,45 @@
       </a>
       <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
         <a href="#" class="stat-card-link" data-type="target_repair_time_breached_open" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached_open')">
-          <%= render 'dashboards/stat_card', title: "Target Repair Time Breached - (Open)", value: @stats[:response_breached_tickets_open_last_30_days], id: "target_repair_time_breached_open", class: 'col-span-1'  %>
+          <%= render 'dashboards/stat_card', title: "(Open)", value: @stats[:response_breached_tickets_open_last_30_days], id: "target_repair_time_breached_open", class: 'col-span-1'  %>
         </a>
         <a href="#" class="stat-card-link" data-type="target_repair_time_breached_closed" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached_closed')">
-          <%= render 'dashboards/stat_card', title: "Target Repair Time Breached - (Closed)", value: @stats[:response_breached_tickets_closed_last_30_days], id: "target_repair_time_breached_closed", class: 'col-span-1'  %>
+          <%= render 'dashboards/stat_card', title: "(Closed)", value: @stats[:response_breached_tickets_closed_last_30_days], id: "target_repair_time_breached_closed", class: 'col-span-1'  %>
         </a>
       </div>
     </div>
     <div>
-    <a href="#" class="stat-card-link" data-type="target_resolution_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached')">
-      <%= render 'dashboards/stat_card', title: "Target Resolution Time - Breached", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
-    </a>
+      <a href="#" class="stat-card-link" data-type="target_resolution_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached')">
+        <%= render 'dashboards/stat_card', title: "Target Resolution Time - Breached", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
+      </a>
       <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
         <a href="#" class="stat-card-link" data-type="target_resolution_time_breached_open" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached_open')">
-          <%= render 'dashboards/stat_card', title: "Target Resolution Time Breached - (Open)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached_open", class: 'col-span-1'  %>
+          <%= render 'dashboards/stat_card', title: "(Open)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached_open", class: 'col-span-1'  %>
         </a>
         <a href="#" class="stat-card-link" data-type="target_resolution_time_breached_closed" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached_open')">
-          <%= render 'dashboards/stat_card', title: "Target Resolution Time Breached - (Closed)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached_closed", class: 'col-span-1'  %>
+          <%= render 'dashboards/stat_card', title: "(Closed)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached_closed", class: 'col-span-1'  %>
         </a>
       </div>
-
     </div>
+    <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
+        <div class="grid sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-3 gap-6">
+          <a href="#" class="stat-card-link" data-type="target_repair_time_not_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_not_breached')">
+            <%= render 'dashboards/stat_card', title: "Target Repair Time - Not Breached", value: @stats[:not_response_breached_tickets_last_30_days], id: "target_repair_time_not_breached", class: 'col-span-1'  %>
+          </a>
+          <a href="#" class="stat-card-link" data-type="target_resolution_time_not_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_not_breached')">
+            <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached", class: 'col-span-1'  %>
+          </a>
+          <a href="#" class="stat-card-link" data-type="no_sla_population" onclick="fetchTicketDetails('<%= @selected_team %>', 'no_sla_population')">
+            <%= render 'dashboards/stat_card', title: "No SLA-(NEW FEATURE)", value: @stats[:no_sla_tickets_last_30_days], id: "no_sla_population", class: 'col-span-1'  %>
+          </a>
+        </div>
+      </div>
     <!-- target repair time not breach -->
-    <a href="#" class="stat-card-link" data-type="target_repair_time_not_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_not_breached')">
-      <%= render 'dashboards/stat_card', title: "Target Repair Time - Not Breached", value: @stats[:not_response_breached_tickets_last_30_days], id: "target_repair_time_not_breached", class: 'col-span-1'  %>
-    </a>
-    <a href="#" class="stat-card-link" data-type="target_resolution_time_not_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_not_breached')">
-      <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached", class: 'col-span-1'  %>
-    </a>
-
       <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
           <a href="#" class="stat-card-link" data-type="total_tickets_last_30_days" onclick="fetchTicketDetails('<%= @selected_team %>', 'total_tickets_last_30_days')">
             <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days"%>
           </a>
-      </div>
+      </div>      
   </div>
 
   <!-- Charts Section -->
@@ -271,6 +276,7 @@
         document.getElementById("target_repair_time_breached_closed").innerText = data.response_breached_tickets_closed_last_30_days;
         document.getElementById("target_resolution_time_breached_open").innerText = data.resolution_breached_open_last_30_days;
         document.getElementById("target_resolution_time_breached_closed").innerText = data.resolution_breached_closed_last_30_days;
+        document.getElementById("no_sla_population").innerText = data.no_sla_tickets_last_30_days;
 
         // Refresh charts
         document.getElementById("responseTimeChart").innerHTML = "";


### PR DESCRIPTION
This pull request introduces a new feature to track tickets with no SLA (Service Level Agreement) in the dashboard. The most important changes include updates to the `fetch_stats` method, filtering options, and the dashboard view.

### Dashboard Enhancements:

* [`app/controllers/dashboards_controller.rb`](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5R56-R59): Added logic to count and include tickets with no SLA in the `fetch_stats` method and updated the `tickets` method to filter tickets based on the new 'no_sla_population' status. [[1]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5R56-R59) [[2]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5R109) [[3]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5R166-R167)

* [`app/views/dashboards/index.html.erb`](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L38-R41): Updated the dashboard view to display the count of tickets with no SLA, including adding a new stat card and updating the JavaScript to refresh the new data. [[1]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L38-R41) [[2]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L51-R71) [[3]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60R279)