### PR TITLE
Remove the import channel js

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,4 +9,4 @@ import '@rails/actiontext';
 //= require_tree .
 //= require 'chartkick'
 //= require 'chart.js'
-import "./channels"
+// import "./channels"


### PR DESCRIPTION
This pull request includes a modification to the `app/javascript/application.js` file to comment out the import statement for `./channels`.

Changes in `app/javascript/application.js`:

* Commented out the import statement for `./channels`.