### PR TITLE
Refactor form layout in _form.html.erb to improve structure

### DIFF
--- a/app/views/tickets/_form.html.erb
+++ b/app/views/tickets/_form.html.erb
@@ -1,5 +1,6 @@
 <%= render 'tickets/new_back' %>
-<%= form_with(model: [project, project.tickets.build], method: :post, data: { turbo: false }) do |f| %>  <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-[100%] p-1">
+<%= form_with(model: [project, project.tickets.build], data: { turbo: false }) do |f| %>
+  <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-[100%] p-1">
     <div class="grid grid-cols-2 gap-2 h-[100%] w-[100%]">
 
       <!-- Issue Field -->


### PR DESCRIPTION
This pull request includes a small change to the `app/views/tickets/_form.html.erb` file. The change removes the `method: :post` parameter from the `form_with` helper, which is the default method for form submissions, and adjusts the indentation for better readability.

* [`app/views/tickets/_form.html.erb`](diffhunk://#diff-0c8e6f1d2ab8cb8ba63fa746c934146339564bb03ab4480c50b87af1a8e1f3f7L2-R3): Removed `method: :post` from the `form_with` helper and adjusted the indentation.