### PR TITLE
Return back the notifications

### DIFF
--- a/app/channels/notifications_channel.rb
+++ b/app/channels/notifications_channel.rb
@@ -1,0 +1,5 @@
+class NotificationsChannel < ApplicationCable::Channel
+  def subscribed
+    stream_for current_user
+  end
+end


### PR DESCRIPTION
This pull request introduces a new `NotificationsChannel` class to handle real-time notifications for users. 

Key changes include:

* [`app/channels/notifications_channel.rb`](diffhunk://#diff-d9f7bbbbf8ccb01abae77a31cbc0bad979ba357211f316255dabcb88c5387857R1-R5): Added a new `NotificationsChannel` class that inherits from `ApplicationCable::Channel`. This class includes a `subscribed` method that starts streaming notifications for the current user.