### PR TITLE
Remove unused route 'index_home' from tickets resource in routes.rb

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -357,6 +357,11 @@ class TicketsController < ApplicationController
     end
   end
 
+  def non_breached_sla_tickets
+    @project = Project.find(params[:project_id])
+    @tickets = @project.tickets.joins(:sla_tickets).where("sla_tickets.sla_status = 'Not Breached'")
+  end
+
   private
 
   def set_project

--- a/app/views/data_center/orm_report.html.erb
+++ b/app/views/data_center/orm_report.html.erb
@@ -67,12 +67,12 @@
         <% project = Project.find(project_id) %>
         <tr>
           <td class="capitalize border border-black px-4 py-2" rowspan="<%= @project_status_counts.select { |k, _| k.first == project_id }.size + 1 %>"><%= project.title %></td>
-          <td class="border border-black px-4 py-2" rowspan="<%= @project_status_counts.select { |k, _| k.first == project_id }.size + 1 %>"><%= total_count %></td>
+          <td class="border border-black px-4 py-2 text-center" rowspan="<%= @project_status_counts.select { |k, _| k.first == project_id }.size + 1 %>"><%= total_count %></td>
         </tr>
         <% @project_status_counts.select { |k, _| k.first == project_id }.each do |(proj_id, status), count| %>
           <tr>
-            <td class="border border-black px-4 py-2"><%= status %></td>
-            <td class="border border-black px-4 py-2"><%= count %></td>
+            <td class="border border-black px-4 py-2 text-center"><%= status %></td>
+            <td class="border border-black px-4 py-2 text-center"><%= count %></td>
           </tr>
         <% end %>
       <% end %>

--- a/app/views/data_center/orm_team_report.html.erb
+++ b/app/views/data_center/orm_team_report.html.erb
@@ -6,7 +6,6 @@
         <%= f.label :days, "Closed & Resolved for the last (days)", class: "capitalize text-sm font-bold w-full align-middle p-2" %>
         <%= f.number_field :days, value: params[:days] || 0, min: 0, class: "border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg dark:text-black w-full p-2" %>
       </div>
-      </div>
       <div class="flex flex-col gap-2">
         <%= f.label :team_id, "Team", class: "capitalize text-sm font-bold w-full align-middle p-2" %>
         <div class="relative w-full">
@@ -63,12 +62,12 @@
         <% project = Project.find(project_id) %>
         <tr>
           <td class="capitalize border border-black px-4 py-2" rowspan="<%= @project_status_counts.select { |k, _| k.first == project_id }.size + 1 %>"><%= project.title %></td>
-          <td class="border border-black px-4 py-2" rowspan="<%= @project_status_counts.select { |k, _| k.first == project_id }.size + 1 %>"><%= total_count %></td>
+          <td class="border border-black px-4 py-2 text-center" rowspan="<%= @project_status_counts.select { |k, _| k.first == project_id }.size + 1 %>"><%= total_count %></td>
         </tr>
         <% @project_status_counts.select { |k, _| k.first == project_id }.each do |(proj_id, status), count| %>
           <tr>
-            <td class="border border-black px-4 py-2"><%= status %></td>
-            <td class="border border-black px-4 py-2"><%= count %></td>
+            <td class="border border-black px-4 py-2 text-center"><%= status %></td>
+            <td class="border border-black px-4 py-2 text-center"><%= count %></td>
           </tr>
         <% end %>
       <% end %>

--- a/app/views/tickets/non_breached_sla_tickets.html.erb
+++ b/app/views/tickets/non_breached_sla_tickets.html.erb
@@ -1,0 +1,162 @@
+<table class="min-w-full bg-white dark:bg-gray-800">
+  <thead>
+  <tr>
+    <th class="py-2 px-4 border-b">ID</th>
+    <th class="py-2 px-4 border-b">Issue</th>
+    <th class="py-2 px-4 border-b">Priority</th>
+    <th class="py-2 px-4 border-b">Project</th>
+    <th class="py-2 px-4 border-b">Actions</th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @tickets.each do |ticket| %>
+    <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">
+      <th scope="row" class="px-2 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white uppercase">
+        <%= link_to ticket.unique_id, project_ticket_path(ticket.project, ticket) if ticket.unique_id.present? %>
+      </th>
+      <th scope="row" class="px-2 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+        <%= link_to ticket.created_at.strftime("%d %b %Y"), project_ticket_path(ticket.project, ticket) %>
+      </th>
+      <th scope="row" class="px-2 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+        <%= link_to ticket.issue, project_ticket_path(ticket.project, ticket) %>
+      </th>
+      <td class="px-2 py-2">
+        <% case ticket.priority %>
+        <% when 'SEVERITY 1' %>
+          <p class='bg-red-900 p-1 text-center text-white font-bold rounded'><%= ticket.priority %></p>
+        <% when 'SEVERITY 2' %>
+          <p class='bg-red-600 p-1 text-center text-white font-bold rounded'><%= ticket.priority %></p>
+        <% when 'SEVERITY 3' %>
+          <p class='bg-yellow-500 p-1 text-center text-white font-bold rounded'><%= ticket.priority %></p>
+        <% else %>
+          <p class='bg-blue-500 p-1 text-center text-white font-bold rounded'><%= ticket.priority %></p>
+        <% end %>
+      </td>
+      <td class="px-2 py-2 truncate w-64">
+        <%= ticket.subject.truncate(50) if ticket.subject.present? %>
+      </td>
+      <td class="px-2 py-2 font-bold">
+        <% ticket.users.each do |user| %>
+          <%= user.name if user.name.present? %>
+        <% end %>
+      </td>
+      <td class="px-2 py-2">
+        <% ticket.statuses.each do |status| %>
+          <% case status.name %>
+        <% when 'Resolved' %>
+            <p class='bg-green-500 text-center text-slate-100 font-semibold rounded p-1 border-r-2 border-b-4 border-green-600'>
+              <%= status.name %>
+            </p>
+          <% when 'Closed' %>
+            <p class='bg-gray-800 text-center text-slate-100 font-semibold rounded p-1 border-r-2 border-b-4 border-gray-900'>
+              <%= status.name %>
+            </p>
+          <% when 'Reopened' %>
+            <p class="bg-red-900 text-center text-slate-100 font-semibold rounded p-1 border-r-2 border-b-4 border-red-800">
+              <%= status.name %>
+            </p>
+          <% when 'New' %>
+            <p class="bg-red-500 text-center text-slate-100 font-semibold rounded p-1 border-r-2 border-b-4 border-red-600">
+              <%= status.name %>
+            </p>
+          <% when 'Under Development' %>
+            <p class='bg-blue-300 text-center text-slate-100 font-semibold rounded p-1 border-r-2 border-b-4 border-blue-400'>
+              <%= status.name %>
+            </p>
+          <% when 'Work in Progress' %>
+            <p class='bg-gray-500 text-center text-slate-100 font-semibold rounded p-1 border-r-2 border-b-4 border-gray-600'>
+              <%= status.name %>
+            </p>
+          <% when 'QA Testing' %>
+            <p class='bg-pink-500 text-center text-slate-100 font-semibold rounded p-1 border-r-2 border-b-4 border-pink-600'>
+              <%= status.name %>
+            </p>
+          <% when 'Awaiting Build' %>
+            <p class='text-center text-gray-900 dark:text-slate-100 font-semibold rounded p-1 border-black dark:border-slate-100 border border-b-4 border-r-2'>
+              <%= status.name %>
+            </p>
+          <% when 'Client Confirmation Pending' %>
+            <p class='bg-purple-500 text-center text-slate-100 font-semibold rounded p-1 border-r-2 border-b-4 border-purple-600'>
+              <%= status.name %>
+            </p>
+          <% when 'On-Hold' %>
+            <p class='bg-yellow-300 text-center text-black font-semibold rounded p-1 border-r-2 border-b-4 border-yellow-400'>
+              <%= status.name %>
+            </p>
+          <% when 'Assigned' %>
+            <p class='bg-blue-800 text-center text-slate-100 font-semibold rounded p-1 border-r-2 border-b-4 border-blue-900'>
+              <%= status.name %>
+            </p>
+          <% when 'Approved' %>
+            <p class='bg-green-800 text-center text-slate-100 font-bold rounded p-1 border-r-2 border-b-4 border-green-900'>
+              <%= status.name %>
+            </p>
+          <% when 'Pending' %>
+            <p class='bg-gradient-to-r from-green-800 to-black text-center text-slate-100 font-bold rounded p-1 border-r-2 border-b-4 border-green-900'>
+              <%= status.name %>
+            </p>
+          <% when 'Declined' %>
+            <p class='bg-gray-800 text-center text-slate-100 font-semibold rounded p-1 border-r-2 border-b-4 border-gray-900'>
+              <%= status.name %>
+            </p>
+          <% end %>
+        <% end %>
+      </td>
+      <!-- Progress Bar -->
+      <td class="pl-2 pr-5 py-2">
+        <div class="relative w-full">
+          <!-- Progress Percentage Tooltip -->
+          <div class="absolute top-[-1.5rem] left-0 translate-x-0 text-sm font-bold"
+               style="left: calc(<%= ticket.progress_percentage || 0 %>% - 1rem); color: <%= if ticket.progress_percentage.nil?
+                                                                                      '#9CA3AF' # gray-400
+                                                                                    elsif ticket.progress_percentage < 30
+                                                                                      '#DC2626' # red-600
+                                                                                    elsif ticket.progress_percentage < 60
+                                                                                      '#2563EB' # blue-600
+                                                                                    else
+                                                                                      ticket.progress_percentage >= 100 ? '#000000' : '#16A34A' # black or green-600
+                                                                                    end %>;"
+               class="<%= 'mr-3' if ticket.progress_percentage == 100 %>">
+            <%= ticket.progress_percentage || 0 %>%
+          </div>
+          <!-- Progress Bar Background -->
+          <div class="bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+            <!-- Dynamic Progress Bar -->
+            <div class="<%= if ticket.progress_percentage.nil?
+                              'bg-gray-400'
+                            elsif ticket.progress_percentage < 30
+                              'bg-red-600'
+                            elsif ticket.progress_percentage < 60
+                              'bg-blue-600'
+                            else
+                              ticket.progress_percentage >= 100 ? 'bg-black ' : 'bg-green-600'
+                            end %> h-2.5 rounded-full"
+                 style="width: <%= ticket.progress_percentage || 0 %>%">
+            </div>
+          </div>
+        </div>
+      </td>
+      <td class="px-2 py-2 capitalize">
+        <%= ticket.user.name if ticket.user.name.present? %>
+      </td>
+      <td class="px-2 py-2">
+        <%= link_to 'VIEW', project_ticket_path(ticket.project, ticket), class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100' %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
+<!-- Pagination Links -->
+<div class="mt-4">
+  <% if @page > 1 %>
+    <%= link_to 'Previous', sla_breached_tickets_project_tickets_path(@project, page: @page - 1),
+                class: 'bg-blue-600 hover:bg-blue-500 px-4 rounded text-white text-sm font-semibold transition-all p-2 uppercase'
+    %>
+  <% end %>
+  <% if @page < @total_pages %>
+    <%= link_to 'Next', sla_breached_tickets_project_tickets_path(@project, page: @page + 1),
+                class: 'bg-blue-600 hover:bg-blue-500 px-4 rounded text-white text-sm font-semibold transition-all p-2 uppercase'
+    %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
     resources :tickets do
       collection do
         get 'all_tickets'
+        get 'non_breached_sla_tickets'
       end
       member do
         post :assign_tag


### PR DESCRIPTION
This pull request introduces a new feature to list non-breached SLA tickets and includes several improvements to the user interface for better readability and user experience. The most important changes include adding a new action in the `tickets_controller`, updating views to center-align text, and adding a new route.

New feature for non-breached SLA tickets:

* Added `non_breached_sla_tickets` action in `tickets_controller` to fetch tickets with non-breached SLA status. (`app/controllers/tickets_controller.rb`)
* Created a new view `non_breached_sla_tickets.html.erb` to display non-breached SLA tickets in a table format with detailed ticket information and pagination. (`app/views/tickets/non_breached_sla_tickets.html.erb`)
* Added a new route for `non_breached_sla_tickets` in `config/routes.rb` to enable the new action. (`config/routes.rb`)

User interface improvements:

* Center-aligned text in `orm_report.html.erb` for better readability. (`app/views/data_center/orm_report.html.erb`)
* Center-aligned text in `orm_team_report.html.erb` to maintain consistency with other views. (`app/views/data_center/orm_team_report.html.erb`)

These changes collectively enhance the functionality and user experience of the application.