### PR TITLE
Remove unused route 'index_home' from tickets resource in routes.rb

### DIFF
--- a/app/views/data_center/orm_report.html.erb
+++ b/app/views/data_center/orm_report.html.erb
@@ -78,7 +78,6 @@
       <% end %>
       </tbody>
     </table>
-
     <table id="orm_report" class="table-auto w-full">
       <thead>
       <tr>


### PR DESCRIPTION
This pull request includes a small change to the `app/views/data_center/orm_report.html.erb` file. The change removes an unnecessary blank line before the ORM report table.