### PR TITLE
Remove redundant path display in active users section for cleaner UI

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,7 +23,7 @@
       <%= link_to active_client_users_path, class: 'flex items-center justify-between w-full' do %>
       <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
         <p class="text-xs sm:text-sm truncate">
-          Active Clients<br>(Clients who have login more than once)
+          Active Clients<br>(Clients who have logged in more than once)
         </p>
         <span class="text-lg sm:text-xl font-bold">
           <%= User.joins(:roles).where(roles: { name: 'client' }).where('sign_in_count > ?', 0).count %>
@@ -32,7 +32,7 @@
       <% end %>
       <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
         <p class="text-xs sm:text-sm truncate">
-          Active Project Manager<br>(Project Managers who have login more than once)
+          Active Project Manager<br>(Project Managers who have logged in more than once)
         </p>
         <span class="text-lg sm:text-xl font-bold">
           <%= User.joins(:roles).where(roles: { name: 'project manager' }).where('sign_in_count > ?', 0).count %>
@@ -40,7 +40,7 @@
       </div>
       <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
         <p class="text-xs sm:text-sm truncate">
-          Active Internal Users<br>(Agents who have login more than once)
+          Active Internal Users<br>(Agents who have logged in more than once)
         </p>
         <span class="text-lg sm:text-xl font-bold">
           <%= User.joins(:roles).where(roles: { name: 'agent' }).where('sign_in_count > ?', 0).count %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,7 +13,7 @@
       <%= link_to active_users_path, class: 'flex items-center justify-between w-full' do %>
       <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
         <p class="text-xs sm:text-sm truncate">
-          Active Users<br>(User who have login more than once)
+          Active Users<br>(Users who have logged in more than once)
         </p>
         <span class="text-lg sm:text-xl font-bold">
           <%= User.joins(:roles).where(roles: { name: ['client','project manager','admin','agent','observer'] }).where('sign_in_count > ?', 0).count %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,7 +13,7 @@
       <%= link_to active_users_path, class: 'flex items-center justify-between w-full' do %>
       <div class="col-span-1 flex items-center dark:bg-gray-700 justify-between p-3 sm:p-4 h-20 sm:h-24 rounded shadow hover:shadow-lg w-full">
         <p class="text-xs sm:text-sm truncate">
-          Active Users<br>(User who have login more than once) <%= active_users_path %>
+          Active Users<br>(User who have login more than once)
         </p>
         <span class="text-lg sm:text-xl font-bold">
           <%= User.joins(:roles).where(roles: { name: ['client','project manager','admin','agent','observer'] }).where('sign_in_count > ?', 0).count %>


### PR DESCRIPTION
This pull request includes a minor change to the `app/views/home/index.html.erb` file. The change removes the redundant display of the `active_users_path` URL from the "Active Users" section.

* [`app/views/home/index.html.erb`](diffhunk://#diff-70acf32a949fd60a5a3d1ae8bbca9090058a7f011f201c41e6a8b1a51ea12c02L16-R16): Removed the redundant display of the `active_users_path` URL from the "Active Users" section.