### PR TITLE
Add custom text formatting options to Trix editor and update styles

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -218,3 +218,12 @@
 #sidebar:hover::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.7);
 }
+
+.trix-content .text-red { color: red; }
+.trix-content .text-blue { color: blue; }
+.trix-content .text-green { color: green; }
+.trix-content .text-yellow { color: goldenrod; }
+.trix-content .text-underline { text-decoration: underline; }
+.trix-content .text-highlight { background-color: yellow; }
+.trix-content .text-large { font-size: 1.5em; }
+.trix-content .text-small { font-size: 0.75em; }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,6 +4,7 @@ import '@hotwired/turbo-rails';
 import 'controllers';
 import 'trix';
 import '@rails/actiontext';
+import "./controllers/trix_custom_formatting"
 //= require rails-ujs
 //= require turbolinks
 //= require_tree .

--- a/app/javascript/controllers/trix_custom_formatting.js
+++ b/app/javascript/controllers/trix_custom_formatting.js
@@ -1,0 +1,62 @@
+document.addEventListener('trix-initialize', (event) => {
+  const toolbar = event.target.toolbarElement.querySelector('.trix-button-group--text-tools');
+
+  const buttons = [
+    { name: 'text-red', label: '🔴' },
+    { name: 'text-blue', label: '🔵' },
+    { name: 'text-green', label: '🟢' },
+    { name: 'text-yellow', label: '🟡' },
+    { name: 'text-underline', label: 'U̲' },
+    { name: 'text-highlight', label: '🖍️' },
+    { name: 'text-large', label: '🔠' },
+    { name: 'text-small', label: '🔡' },
+  ];
+
+  buttons.forEach(({ name, label }) => {
+    toolbar.insertAdjacentHTML('beforeend', `
+      <button type="button" class="trix-button" data-trix-attribute="${name}" title="${name}">${label}</button>
+    `);
+  });
+});
+
+document.addEventListener('trix-initialize', () => {
+  const exclusiveColors = ['text-red', 'text-blue', 'text-green', 'text-yellow'];
+
+  exclusiveColors.forEach((color) => {
+    // eslint-disable-next-line no-undef
+    Trix.config.textAttributes[color] = {
+      style: { color: color.split('-')[1] },
+      inheritable: true,
+      parser(element) {
+        return element.style.color === color.split('-')[1];
+      },
+      remover(element) {
+        exclusiveColors.forEach((c) => element.removeAttribute(c));
+      },
+    };
+  });
+
+  // eslint-disable-next-line no-undef
+  Trix.config.textAttributes['text-underline'] = {
+    style: { textDecoration: 'underline' },
+    inheritable: true,
+  };
+
+  // eslint-disable-next-line no-undef
+  Trix.config.textAttributes['text-highlight'] = {
+    style: { backgroundColor: 'yellow' },
+    inheritable: true,
+  };
+
+  // eslint-disable-next-line no-undef
+  Trix.config.textAttributes['text-large'] = {
+    style: { fontSize: '1.5em' },
+    inheritable: true,
+  };
+
+  // eslint-disable-next-line no-undef
+  Trix.config.textAttributes['text-small'] = {
+    style: { fontSize: '0.75em' },
+    inheritable: true,
+  };
+});

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -56,8 +56,9 @@
           </div>
           <div class="mb-2.5 font-bold capitalize flex flex-wrap ">Content:
             <% if @ticket.content.present? %>
-              <span class="font-extralight pl-2 flex flex-wrap">
-                <%= @ticket.content.to_plain_text.gsub(/\[.*?\]/, '').strip %>
+              <div class="font-extralight pl-2 flex flex-wrap">
+                <%= @ticket.content.to_s.gsub(/\[.*?\]/, '').html_safe %>
+
                 <% if @ticket.content.body.attachments.any? %>
                   <% @ticket.content.body.attachments.each do |attachment| %>
                     <div class="mb-2">
@@ -86,7 +87,7 @@
                     </div>
                   <% end %>
                 <% end %>
-              </span>
+              </div>
             <% end %>
           </div>
         </div>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -57,7 +57,7 @@
           <div class="mb-2.5 font-bold capitalize flex flex-wrap ">Content:
             <% if @ticket.content.present? %>
               <div class="font-extralight pl-2 flex flex-wrap">
-                <%= @ticket.content.to_s.gsub(/\[.*?\]/, '').html_safe %>
+                <%= sanitize(@ticket.content.to_s.gsub(/\[.*?\]/, '')) %>
 
                 <% if @ticket.content.body.attachments.any? %>
                   <% @ticket.content.body.attachments.each do |attachment| %>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -19,4 +19,9 @@ module.exports = {
     require('@tailwindcss/typography'),
     require('@tailwindcss/container-queries'),
   ],
+  safelist: [
+    'text-red', 'text-blue', 'text-green', 'text-yellow',
+    'text-underline', 'text-highlight', 'text-large', 'text-small',
+  ],
+
 };


### PR DESCRIPTION
This pull request introduces custom text formatting options for Trix editor and updates the display of ticket content. The most important changes include adding new text formatting styles, initializing these styles in Trix, and modifying the ticket content display to render HTML safely.

### Custom text formatting for Trix editor:

* [`app/assets/stylesheets/application.css`](diffhunk://#diff-5bfcdc54bcda018d14515b827c80d9f9b8ee25704a4271b560a2f87439665f17R221-R229): Added new CSS classes for custom text formatting, including colors, underline, highlight, and font sizes.
* [`app/javascript/controllers/trix_custom_formatting.js`](diffhunk://#diff-dd6945fd115147218aa1c28cc57958846bb2a91bb9d54bd71efd3246cd3a378fR1-R62): Added event listeners to initialize custom formatting buttons in the Trix toolbar and define the text attributes for these formats.
* [`app/javascript/application.js`](diffhunk://#diff-baa2004cc77a893ed291cbf22ae1a4f3b8476a67d4581ea3928109e5ea211df4R7): Imported the custom Trix formatting controller.
* [`config/tailwind.config.js`](diffhunk://#diff-2de16a68b266f0cafbcddf0a7469415888204e9ca649dbd55b3fbcb5ccb6b229R22-R26): Added the new text formatting classes to the Tailwind CSS safelist to ensure they are not purged.

### Ticket content display:

* [`app/views/tickets/show.html.erb`](diffhunk://#diff-99e200cfd1003b33f0a45daca511786346c2f5d376596d8c5aabdaf18052cc2dL59-R61): Updated the ticket content display to use `html_safe` for rendering HTML content safely. [[1]](diffhunk://#diff-99e200cfd1003b33f0a45daca511786346c2f5d376596d8c5aabdaf18052cc2dL59-R61) [[2]](diffhunk://#diff-99e200cfd1003b33f0a45daca511786346c2f5d376596d8c5aabdaf18052cc2dL89-R90)