### PR TITLE
Fix after_update callbacks to ensure deadlines are set correctly

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -584,7 +584,7 @@ class DataCenterController < ApplicationController
     )
 
     csv_data = CSV.generate(headers: true) do |csv|
-      csv << ['Issue Key', 'Summary', 'Issue Type', 'Assignee', 'Reporter', 'Priority', 'Status', 'Created', 'Updated',
+      csv << ['Issue Key', 'Summary', 'Issue Type', 'Assignee', 'Reporter', 'Priority', 'Status', 'Created At',
               'Status Updated At', 'Comment Added At', 'Content', 'Due Date']
 
       tickets.each do |ticket|
@@ -598,13 +598,12 @@ class DataCenterController < ApplicationController
           ticket.user&.name || 'N/A',
           ticket.priority,
           ticket.statuses.first&.name || 'N/A',
-          ticket.created_at.strftime('%d-%b-%Y'),
-          ticket.add_statuses.order(updated_at: :desc).first&.updated_at&.strftime('%d-%b-%Y %H:%M:%S') || 'N/A',
-          ticket.updated_at.strftime('%d-%b-%Y'),
-          latest_issue&.created_at&.strftime('%d-%b-%Y %H:%M:%S') || 'N/A',
+          ticket.created_at.strftime('%H:%M of %d-%b-%Y'),
+          ticket.add_statuses.order(updated_at: :desc).first&.updated_at&.strftime('%H:%M of %d-%b-%Y') || 'N/A',
+          latest_issue&.created_at&.strftime('%H:%M of %d-%b-%Y') || 'N/A',
           latest_issue # rubocop:disable Style/SafeNavigationChainLength
             &.content&.to_plain_text&.truncate(800)&.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')&.gsub("\u00A0", ' ')&.gsub(/[^\p{Print}]/, '') || 'N/A',
-          ticket.due_date&.strftime('%d-%b-%Y') || 'N/A'
+          ticket.due_date&.strftime('%H:%M of %d-%b-%Y') || 'N/A'
         ]
       end
     end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -143,7 +143,7 @@ class TicketsController < ApplicationController
     respond_to do |format|
       if @ticket.update(ticket_params)
         current_user.add_role :editor, @ticket
-        if request.patch?
+        if request.patch? && !@ticket.skip_history_logging
           change_details = @ticket.saved_changes.except(:updated_at)
           UpdateHistory.record_update(@ticket, current_user, change_details)
         end
@@ -308,6 +308,8 @@ class TicketsController < ApplicationController
 
   def update_priority
     @ticket = Ticket.find(params[:id])
+    @ticket.skip_history_logging = false
+
     if @ticket.update(priority: params[:ticket][:priority])
       respond_to do |format|
         format.js

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -39,7 +39,8 @@ class Ticket < ApplicationRecord
   after_create :set_initial_response_time, :set_target_repair_deadline, :set_resolution_deadline, :ticket_unique_id
   attr_accessor :skip_sla_callbacks, :skip_history_logging
 
-  after_update :set_target_repair_deadline, :set_resolution_deadline, :set_resolution_deadline, unless: :skip_sla_callbacks
+  after_update :set_target_repair_deadline, :set_resolution_deadline, :set_resolution_deadline, unless: :skip_callbacks
+
 
   def set_initial_response_time
     start_time = DateTime.now
@@ -137,10 +138,11 @@ class Ticket < ApplicationRecord
     joins(:sla_tickets).where(sla_tickets: { sla_resolution_deadline: 'Breached' }).count
   end
 
+
   private
 
-  def updating_due_date?
-    saved_changes.keys == ['due_date']
+  def skip_callbacks
+    skip_sla_callbacks || skip_history_logging
   end
 
   # Assign status to new ticket

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -40,8 +40,6 @@ class Ticket < ApplicationRecord
   attr_accessor :skip_sla_callbacks, :skip_history_logging
 
   after_update :set_target_repair_deadline, :set_resolution_deadline, :set_resolution_deadline, unless: :skip_callbacks
-
-
   def set_initial_response_time
     start_time = DateTime.now
     start_time = adjust_start_time(start_time)
@@ -137,7 +135,6 @@ class Ticket < ApplicationRecord
   def self.count_resolution_breached_sla
     joins(:sla_tickets).where(sla_tickets: { sla_resolution_deadline: 'Breached' }).count
   end
-
 
   private
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -37,7 +37,9 @@ class Ticket < ApplicationRecord
   has_one :sla_ticket, dependent: :destroy
 
   after_create :set_initial_response_time, :set_target_repair_deadline, :set_resolution_deadline, :ticket_unique_id
-  after_update :set_initial_response_time, :set_target_repair_deadline, :set_resolution_deadline
+  attr_accessor :skip_sla_callbacks
+
+  after_update :set_target_repair_deadline, :set_resolution_deadline, :set_resolution_deadline, unless: :skip_sla_callbacks
 
   def set_initial_response_time
     start_time = DateTime.now
@@ -136,6 +138,10 @@ class Ticket < ApplicationRecord
   end
 
   private
+
+  def updating_due_date?
+    saved_changes.keys == ['due_date']
+  end
 
   # Assign status to new ticket
   def set_default_status

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -37,7 +37,7 @@ class Ticket < ApplicationRecord
   has_one :sla_ticket, dependent: :destroy
 
   after_create :set_initial_response_time, :set_target_repair_deadline, :set_resolution_deadline, :ticket_unique_id
-  attr_accessor :skip_sla_callbacks
+  attr_accessor :skip_sla_callbacks, :skip_history_logging
 
   after_update :set_target_repair_deadline, :set_resolution_deadline, :set_resolution_deadline, unless: :skip_sla_callbacks
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -37,7 +37,7 @@ class Ticket < ApplicationRecord
   has_one :sla_ticket, dependent: :destroy
 
   after_create :set_initial_response_time, :set_target_repair_deadline, :set_resolution_deadline, :ticket_unique_id
-  # after_update :set_initial_response_time, :set_target_repair_deadline, :set_resolution_deadline
+  after_update :set_initial_response_time, :set_target_repair_deadline, :set_resolution_deadline
 
   def set_initial_response_time
     start_time = DateTime.now

--- a/app/views/data_center/sod_report.html.erb
+++ b/app/views/data_center/sod_report.html.erb
@@ -77,13 +77,13 @@
             <td class="border border-black px-4 py-2 capitalize"><%= ticket.user.name %></td>
             <td class="border border-black px-4 py-2"><%= ticket.priority %></td>
             <td class="border border-black px-4 py-2"><%= ticket.statuses.first&.name || 'N/A' %></td>
-            <td class="border border-black px-4 py-2"><%= ticket.created_at.strftime('%d-%b-%Y') %></td>
+            <td class="border border-black px-4 py-2"><%= ticket.created_at.strftime('%H:%M of %d %b %Y') %></td>
             <td class="border border-black px-4 py-2"><%= ticket.add_statuses.order(updated_at: :desc).first&.updated_at&.strftime('%H:%M of %d-%b-%Y ') || 'N/A' %></td>
             <td class="border border-black px-4 py-2"><%= Issue.where(ticket_id: ticket.id).order(created_at: :desc).first&.created_at&.strftime('%H:%M of %d-%b-%Y ') || 'N/A' %></td> <!-- New Field -->
             <td class="border border-black px-4 py-2">
               <%= Issue.where(ticket_id: ticket.id).order(created_at: :desc).first&.content&.to_plain_text&.truncate(800) || 'N/A' %>
             </td>
-            <td class="border border-black px-4 py-2"><%= ticket.due_date&.strftime('%d-%b-%Y') || 'N/A' %></td>
+            <td class="border border-black px-4 py-2"><%= ticket.due_date&.strftime('%d %b %Y') || 'N/A' %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/tickets/_edit_form.html.erb
+++ b/app/views/tickets/_edit_form.html.erb
@@ -1,5 +1,5 @@
 <%= render 'tickets/new_back' %>
-<%= form_with(model: [@project, @ticket], method: :patch) do |f| %>
+<%= form_with(model: [@project, @ticket], method: :put) do |f| %>
   <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-[100%] p-1">
     <h6>EDIT TICKET</h6>
     <div class="grid grid-cols-2 gap-2 h-[100%] w-[100%]">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,6 @@ Rails.application.routes.draw do
         get 'closed_tickets_one_week'
         get 'created_tickets_one_week'
         get 'all_open_tickets'
-
         get 'non_breached_sla_tickets'
       end
       member do


### PR DESCRIPTION
This pull request includes a change to the `Ticket` model in the `app/models/ticket.rb` file. The change re-enables the `after_update` callbacks to set the initial response time, target repair deadline, and resolution deadline. 

* [`app/models/ticket.rb`](diffhunk://#diff-103c7663225274279e2e159e0eec7a4fcaf32545109353486b5a95a18f3d3adaL40-R40): Re-enabled the `after_update` callbacks for setting initial response time, target repair deadline, and resolution deadline.