### PR TITLE
Remove skip_history_logging assignment in update_priority method

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -312,7 +312,6 @@ class TicketsController < ApplicationController
 
   def update_priority
     @ticket = Ticket.find(params[:id])
-    @ticket.skip_history_logging = true
 
     if @ticket.update(priority: params[:ticket][:priority])
       respond_to do |format|


### PR DESCRIPTION
This pull request includes a small change to the `update_priority` method in the `tickets_controller.rb` file. The change removes the line that disables history logging for ticket updates.

* [`app/controllers/tickets_controller.rb`](diffhunk://#diff-d4c5ab3656241a42b628137d4f0e84e6fbaa7bb928bc4569b9cfe442a583ffcdL315): Removed the line `@ticket.skip_history_logging = true` from the `update_priority` method.