### PR TITLE
Update Devise mailer sender to use environment variable

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'cspm@craftsilicon.com'
+  config.mailer_sender =  ENV['SMTP_USERNAME']
 
   # Configure the class responsible to send e-mails.
    config.mailer = 'Devise::Mailer'
@@ -72,7 +72,7 @@ Devise.setup do |config|
   # config.params_authenticatable = true
 
   # Tell if authentication through HTTP Auth is enabled. False by default.
-  # It can be set to an array that will enable http authentication only for the
+  # It can be set to an array that will enable http authenticatio'Devise::Mailer'n only for the
   # given strategies, for example, `config.http_authenticatable = [:database]` will
   # enable it only for database authentication.
   # For API-only applications to support authentication "out-of-the-box", you will likely want to


### PR DESCRIPTION
Replaced the hardcoded email address with `ENV['SMTP_USERNAME']` for the `mailer_sender` to improve configuration flexibility. This change ensures better security and adaptability across different environments.