### PR TITLE
Update Devise mailer sender and production SMTP settings to use hardc…

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,16 +104,16 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: 'secure.emailsrvr.com',
-    port: 465,
-    domain: 'craftsilicon.com', # Remove https:// and just use the domain name
-    user_name: ENV['SMTP_USERNAME'],
-    password: ENV['SMTP_PASSWORD'],
-    authentication: :login, # Add authentication method
-    ssl: true,
-    tls: false, # Remove conflicting TLS when using SSL
-    enable_starttls_auto: false, # Disable STARTTLS when using SSL on port 465
-    openssl_verify_mode: 'none',
-    open_timeout: 30,
-    read_timeout: 30
+    port: 465, # Use 587 for STARTTLS or 465 for SSL/TLS
+    domain: 'craftsilicon.com', # Replace with your domain
+    user_name: 'cspm@craftsilicon.com', # Replace with your email
+    password: '#cspm@123#', # Replace with your email password
+    authentication: 'plain', # Can also be 'plain' or 'cram_md5'
+    ssl: true, # Use SSL encryption
+    tls: true, # Enforce TLS
+    enable_starttls_auto: true, # Automatically start TLS if available
+    openssl_verify_mode: 'none', # To avoid certificate verification issues (use cautiously)
+    open_timeout: 30, # Increase open timeout to 30 seconds
+    read_timeout: 30  # Increase read timeout to 30 seconds
   }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender =  ENV['SMTP_USERNAME']
+  config.mailer_sender = 'cspm@craftsilicon.com'
 
   # Configure the class responsible to send e-mails.
    config.mailer = 'Devise::Mailer'
@@ -72,7 +72,7 @@ Devise.setup do |config|
   # config.params_authenticatable = true
 
   # Tell if authentication through HTTP Auth is enabled. False by default.
-  # It can be set to an array that will enable http authenticatio'Devise::Mailer'n only for the
+  # It can be set to an array that will enable http authentication only for the
   # given strategies, for example, `config.http_authenticatable = [:database]` will
   # enable it only for database authentication.
   # For API-only applications to support authentication "out-of-the-box", you will likely want to


### PR DESCRIPTION
…oded credentials

This pull request updates email configuration settings and fixes a minor typo in the Devise initializer. The most significant changes involve revising SMTP settings in the production environment and updating the default mailer sender in Devise.

### Email Configuration Updates:

* **SMTP settings in `config/environments/production.rb`:** Updated SMTP configuration to include explicit credentials (`user_name` and `password`), adjusted encryption settings (`ssl`, `tls`, `enable_starttls_auto`), and clarified timeout values. These changes aim to improve email delivery reliability and security.
* **Default mailer sender in `config/initializers/devise.rb`:** Changed the default `mailer_sender` from an environment variable to a specific email address (`cspm@craftsilicon.com`).

### Other Fixes:

* **Typo correction in `config/initializers/devise.rb`:** Fixed a comment typo in the HTTP authentication configuration section.