### PR TITLE
Add business manager role to seed data

### DIFF
--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -46,7 +46,7 @@
       <div class="flex flex-wrap">
         <div class="field flex gap-2 m-2">
           <%= f.label :role, class: "flex items-center" %>
-          <%= select_tag :role, options_for_select(Role.where.not(name: %w[creator editor admin]).distinct.pluck(:name, :name)), class: "form-select mt-1 block rounded-md border-gray-300  shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600" %>
+          <%= select_tag :role, options_for_select(Role.where.not(name: %w[creator editor admin observer sales]).distinct.pluck(:name, :name)), class: "form-select mt-1 block rounded-md border-gray-300  shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600" %>
         </div>
         <div class="field flex gap-2 m-2 capitalize">
           <%= f.label ('Select Location'), class: "flex items-center" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -31,7 +31,7 @@
               </div>
             <% end %>
               <% else %>
-            <%= f.collection_check_boxes :role_ids, Role.distinct.all.where.not(name: %w[editor creator admin observer]), :id, :name do |b| %>
+            <%= f.collection_check_boxes :role_ids, Role.distinct.all.where.not(name: %w[editor creator admin observer sales]), :id, :name do |b| %>
               <div class="mb-2">
                 <%= b.check_box(class: "mr-2") %>
                 <%= b.label(class: "ml-2") %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,6 @@ Role.find_or_create_by!(name: 'admin')
 Role.find_or_create_by!(name: 'project manager')
 Role.find_or_create_by!(name: 'client')
 Role.find_or_create_by!(name: 'observer')
-Role.find_or_create_by!(name: 'business manager')
+Role.find_or_create_by!(name: 'sales')
 
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,16 +16,6 @@ Role.find_or_create_by!(name: 'admin')
 Role.find_or_create_by!(name: 'project manager')
 Role.find_or_create_by!(name: 'client')
 Role.find_or_create_by!(name: 'observer')
+Role.find_or_create_by!(name: 'business manager')
 
 
-a = User.create!(email: 'admin@craftsilicon.com', password: 'password', confirmed_at: DateTime.now , confirmation_sent_at: DateTime.now, first_name: 'Jay', last_name: 'Admin')
-a.add_role(:admin)
-
-b = User.create!(email: 'project@craftsilicon.com', password: 'password', confirmed_at: DateTime.now , confirmation_sent_at: DateTime.now, first_name: 'Project', last_name: 'Manager')
-b.add_role('project manager')
-
-c = User.create!(email: 'agent@craftsilicon.com', password: 'password', confirmed_at: DateTime.now , confirmation_sent_at: DateTime.now, first_name: 'Agent', last_name: 'Active')
-c.add_role(:agent)
-
-d = User.create!(email: 'client@craftsilicon.com', password: 'password', confirmed_at: DateTime.now , confirmation_sent_at: DateTime.now, first_name: 'Client', last_name: 'Active')
-d.add_role(:client)


### PR DESCRIPTION
This pull request introduces a new `sales` role and updates the application to reflect this addition. The changes include updates to role selection in forms and the database seeding process.

### Role Management Updates:

* [`app/views/devise/invitations/new.html.erb`](diffhunk://#diff-f8163cf150217d1849f57d58f742bbaf624a0699caf0e9d9d7d5fb936726b7f6L49-R49): Updated the `select_tag` for roles to exclude the new `sales` role from the dropdown, along with other restricted roles such as `creator`, `editor`, `admin`, and `observer`.
* [`app/views/users/edit.html.erb`](diffhunk://#diff-7a664d6e0b1d39425223431cffbf717843cbac2e33ac4fe6a58ecb959e38f6abL34-R34): Modified the `collection_check_boxes` for role selection to exclude the `sales` role, similar to other restricted roles.

### Database Seeding Updates:

* [`db/seeds.rb`](diffhunk://#diff-c61a903a1201b0c7f076b0270377c20390c26f655ce63689d7d843296fcf63f3R19-L31): Added the creation of the `sales` role in the seed data. Additionally, removed the creation of default users and their associated roles to streamline the seeding process.