### PR TITLE
Update bug forms and statuses; add label support

### DIFF
--- a/app/views/bugs/_bugs_content.erb
+++ b/app/views/bugs/_bugs_content.erb
@@ -1,0 +1,35 @@
+<div class="mb-2.5 font-bold capitalize flex flex-wrap ">Content:
+  <% if @bug.content.present? %>
+    <div class="pl-2 flex flex-wrap m-1">
+      <%= raw @bug.content.to_trix_html.gsub(/\[.*?\]/, '').strip %>
+      <% if @bug.content.body.attachments.any? %>
+        <% @bug.content.body.attachments.each do |attachment| %>
+          <div class="mb-2">
+            <% if attachment.attachable.is_a?(ActionText::Attachables::RemoteImage) %>
+              <a href="<%= attachment.attachable.url %>" download>
+                <img src="<%= attachment.attachable.url %>" alt="Remote Image" class="max-w-xs cursor-pointer pl-2">
+              </a>
+              <br>
+              <% if attachment.attachable.is_a?(ActiveStorage::Blob) %>
+                <%= link_to attachment.attachable.filename.to_s, rails_blob_path(attachment.attachable, disposition: 'attachment', only_path: true), target: "_blank", download: true, class: "text-blue-600 hover:underline pl-2" %>
+              <% end %>
+            <% elsif attachment.attachable.is_a?(ActiveStorage::Blob) %>
+              <% if attachment.attachable.previewable? %>
+                <a href="<%= rails_blob_path(attachment.attachable, disposition: 'attachment', only_path: true) %>" download>
+                  <img src="<%= rails_representation_url(attachment.attachable.variant(resize_to_limit: [300, 300])) %>" alt="Attachment Preview" class="max-w-xs cursor-pointer pl-2">
+                </a>
+                <br>
+                <%= link_to attachment.filename.to_s, rails_blob_path(attachment.attachable, only_path: true), target: "_blank", class: "text-blue-600 hover:underline pl-2" %>
+              <% else %>
+                <%= link_to attachment.filename.to_s, rails_blob_path(attachment.attachable, disposition: 'attachment', only_path: true), class: "text-blue-600 hover:underline pl-2" %>
+              <% end %>
+            <% else %>
+              <p>Attachment: <%= attachment.filename.to_s %></p>
+              <%= link_to attachment.filename.to_s, rails_blob_path(attachment.attachable, disposition: 'attachment', only_path: true), class: "text-blue-600 hover:underline pl-2" %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/bugs/_edit_form.erb
+++ b/app/views/bugs/_edit_form.erb
@@ -1,11 +1,11 @@
 <%= form_with(model: [@product, @bug], url: product_bug_path(@product.id, @bug.id), method: :patch, local: true) do |f| %>
   <div class="grid grid-cols-2 gap-2 mt-4">
     <div class="relative z-0 w-[100%] mb-6 group">
-      <%= f.label :issue, 'Issue *', class: "capitalize block mb-1 text-sm font-medium" %><br />
-      <%= f.select :issue, options_for_select(['SUPPORT', 'NEW FEATURE', 'BUG', 'INCIDENT'], @bug.issue), {}, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:text-white", required: true %>
+      <%= f.label :issue, 'Work Type *', class: "capitalize block mb-1 text-sm font-medium" %><br />
+      <%= f.select :issue, options_for_select(['BUG'], @bug.issue), {}, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:text-white", required: true %>
     </div>
     <div class="relative z-0 w-[100%] mb-6 group">
-      <%= f.label :priority, 'Severity *', class: "capitalize block mb-1 text-sm font-medium" %><br />
+      <%= f.label :priority, 'Priority *', class: "capitalize block mb-1 text-sm font-medium" %><br />
       <%= f.select :priority, options_for_select(['SEVERITY 1','SEVERITY 2','SEVERITY 3','SEVERITY 4'], @bug.priority), {}, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:text-white", placeholder: 'Select The Issue', required: true %>
     </div>
   </div>
@@ -17,6 +17,12 @@
     <div class="relative z-0 w-full mb-6 group">
       <%= f.label :images, 'Images', class: "capitalize block mb-1 text-sm font-medium" %><br />
       <%= f.file_field :images, multiple: true, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5" %>
+    </div>
+  </div>
+  <div class="grid grid-cols-2 gap-2 mt-4">
+    <div class="relative z-0 w-full mb-6 group">
+      <%= f.label :label, 'Labels *', class: "capitalize block mb-1 text-sm font-medium" %>
+      <%= f.select :label, options_for_select(['QA','Mobile Banking','Core Banking','USSD'], @bug.label), {}, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:text-white", placeholder: 'Select The Issue', required: true %>
     </div>
   </div>
 

--- a/app/views/bugs/_form.html.erb
+++ b/app/views/bugs/_form.html.erb
@@ -1,11 +1,11 @@
 <%= form_with(model: [@product, @bug], local: true) do |f| %>
   <div class="grid grid-cols-2 gap-2 mt-4">
     <div class="relative z-0 w-[100%] mb-6 group">
-      <%= f.label :issue, 'Issue *', class: "capitalize block mb-1 text-sm font-medium" %><br />
-      <%= f.select :issue, options_for_select(['SUPPORT', 'NEW FEATURE', 'BUG', 'INCIDENT'], @bug.issue), {}, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:text-white", required: true %>
+      <%= f.label :issue, 'Work Type *', class: "capitalize block mb-1 text-sm font-medium" %><br />
+      <%= f.select :issue, options_for_select(['BUG'], @bug.issue), {}, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:text-white", required: true %>
     </div>
     <div class="relative z-0 w-[100%] mb-6 group">
-      <%= f.label :priority, 'Severity *', class: "capitalize block mb-1 text-sm font-medium" %><br />
+      <%= f.label :priority, 'Priority *', class: "capitalize block mb-1 text-sm font-medium" %><br />
       <%= f.select :priority, options_for_select(['SEVERITY 1','SEVERITY 2','SEVERITY 3','SEVERITY 4'], @bug.priority), {}, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:text-white", placeholder: 'Select The Issue', required: true %>
     </div>
   </div>
@@ -21,7 +21,13 @@
   </div>
   <div class="grid grid-cols-2 gap-2 mt-4">
     <div class="relative z-0 w-full mb-6 group">
-      <%= f.label :software_id, 'Product Categories *', class: "capitalize block mb-1 text-sm font-medium" %>
+      <%= f.label :label, 'Labels *', class: "capitalize block mb-1 text-sm font-medium" %>
+      <%= f.select :label, options_for_select(['QA','Mobile Banking','Core Banking','USSD'], @bug.label), {}, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:text-white", placeholder: 'Select The Issue', required: true %>
+    </div>
+  </div>
+  <div class="grid grid-cols-2 gap-2 mt-4">
+    <div class="relative z-0 w-full mb-6 group">
+      <%= f.label :software_id, 'Product *', class: "capitalize block mb-1 text-sm font-medium" %>
       <%= f.collection_select :software_id, @product.softwares, :id, :name,
                               { prompt: "Select Product" },
                               { class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 dark:text-white",

--- a/app/views/bugs/_status_bug.html.erb
+++ b/app/views/bugs/_status_bug.html.erb
@@ -15,7 +15,7 @@
 <% end %>
 <% if current_user.has_role? :admin or current_user.has_role? :agent or  current_user.has_role?('project manager') %>
   <%= form_with url: bug_status_product_bug_path(@product, @bug), local: true do %>
-      <%= select_tag :status_id, options_for_select(Status.where(name: ['TO DO','Awaiting Build','Awaiting Client Information','Blocked','Failed QA', 'In Progress','On-Hold', 'QA Testing', 'Reopened','Support Testing' ]).collect { |status| [status.name, status.id] }, @bug.statuses.first&.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
+      <%= select_tag :status_id, options_for_select(Status.where(name: ['TO DO','Awaiting Build','Awaiting Client API', 'Awaiting Client Information','Blocked','Failed QA', 'In Progress','On-Hold', 'QA Testing', 'Reopened','Support Testing', 'Closed', 'Resolved' ]).collect { |status| [status.name, status.id] }, @bug.statuses.first&.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: 'Select The Status' %>
     <%= submit_tag "UPDATE STATUS", class: 'w-full font-semibold bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100 mt-2' %>
   <% end %>
 <% end %>

--- a/app/views/bugs/show.html.erb
+++ b/app/views/bugs/show.html.erb
@@ -26,7 +26,8 @@
 
     <%= render 'bugs/add_user_remove' %>
     <%= render 'bugs/status_bug' %>
-    <p><%= @bug.content %></p>
     <p><%= @bug.summary %></p>
+    <div><%= render 'bugs/bugs_content' %></div>
+
   </div>
 </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -45,7 +45,7 @@
               <div class="mb-4 text-base font-normal text-gray-500 dark:text-gray-400">
                 <% if comment.content.present? %>
                   <div class="font-extralight pl-2 flex flex-wrap">
-                    <%= comment.content.to_plain_text.gsub(/\[.*?\]/, '').strip %>
+                    <%= raw comment.content.to_trix_html.gsub(/\[.*?\]/, '').strip %>
                     <% if comment.content.body.attachments.any? %>
                       <% comment.content.body.attachments.each do |attachment| %>
                         <div class="mb-2">

--- a/app/views/issues/_issues_table.html.erb
+++ b/app/views/issues/_issues_table.html.erb
@@ -62,7 +62,7 @@
             Posted on <%= item.created_at.strftime("%I:%M %p at %d %B %Y") %>
           </time>
           <div class="mb-4 text-base font-normal text-gray-500 dark:text-gray-400 trix-content">
-            <%= item.content.to_plain_text.gsub(/\[.*?\]/, '').strip %>
+            <%= raw item.content.to_trix_html.gsub(/\[.*?\]/, '').strip %>
             <% if item.content.body.attachments.any? %>
               <% item.content.body.attachments.each do |attachment| %>
                 <div class="mb-2">

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -57,7 +57,7 @@
           <div class="mb-2.5 font-bold capitalize flex flex-wrap ">Content:
             <% if @ticket.content.present? %>
               <div class="font-extralight pl-2 flex flex-wrap m-1">
-                <%= @ticket.content.to_plain_text.gsub(/\[.*?\]/, '').strip %>
+                <%= raw @ticket.content.to_trix_html.gsub(/\[.*?\]/, '').strip %>
                 <% if @ticket.content.body.attachments.any? %>
                   <% @ticket.content.body.attachments.each do |attachment| %>
                     <div class="mb-2">

--- a/db/migrate/20250519071430_add_label_to_bugs.rb
+++ b/db/migrate/20250519071430_add_label_to_bugs.rb
@@ -1,0 +1,5 @@
+class AddLabelToBugs < ActiveRecord::Migration[7.2]
+  def change
+    add_column :bugs, :label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_14_075416) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_19_071430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -119,6 +119,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_14_075416) do
     t.uuid "software_id"
     t.uuid "groupware_id"
     t.uuid "script_id"
+    t.string "label"
     t.index ["groupware_id"], name: "index_bugs_on_groupware_id"
     t.index ["product_id"], name: "index_bugs_on_product_id"
     t.index ["script_id"], name: "index_bugs_on_script_id"


### PR DESCRIPTION
Refactor bug forms to use updated naming conventions (e.g., "Work Type" and "Priority") and simplify issue options. Add support for "label" selection in forms and introduce new status options ("Awaiting Client API", "Closed", "Resolved"). Include a database migration to add the "label" column to the bugs table.

This pull request introduces updates to the bug forms and database schema to enhance the handling of bug labels, simplify issue types, and expand status options. The most notable changes include adding a new `label` field to the `bugs` table, updating the forms to reflect this new field, restricting issue types to "BUG," and extending the list of available statuses.

### Form Updates:
* Updated `app/views/bugs/_edit_form.erb` and `app/views/bugs/_form.html.erb`:
  * Renamed "Issue" to "Work Type" and restricted the selectable options to "BUG" only. [[1]](diffhunk://#diff-f23a73f12c9ca4417969608fa9f120e3f16e50e20bc12182da6895581cc64562L4-R8) [[2]](diffhunk://#diff-ba441b506ce93a55371c30d3ef439101061fc8c5562fedd8123ac9a29c7305b0L4-R8)
  * Added a new "Labels" field with options such as "QA," "Mobile Banking," "Core Banking," and "USSD." [[1]](diffhunk://#diff-f23a73f12c9ca4417969608fa9f120e3f16e50e20bc12182da6895581cc64562R22-R27) [[2]](diffhunk://#diff-ba441b506ce93a55371c30d3ef439101061fc8c5562fedd8123ac9a29c7305b0L24-R30)
  * Adjusted the label for "Severity" to "Priority" for consistency. [[1]](diffhunk://#diff-f23a73f12c9ca4417969608fa9f120e3f16e50e20bc12182da6895581cc64562L4-R8) [[2]](diffhunk://#diff-ba441b506ce93a55371c30d3ef439101061fc8c5562fedd8123ac9a29c7305b0L4-R8)

### Status Options:
* Expanded the list of available statuses in `app/views/bugs/_status_bug.html.erb` to include "Awaiting Client API," "Closed," and "Resolved."

### Database Schema:
* Added a new `label` column to the `bugs` table via a migration (`db/migrate/20250519071430_add_label_to_bugs.rb`) and updated the schema file accordingly. [[1]](diffhunk://#diff-3588542c1ced8bf396df067874d4a587119937e751e013c7291eec92b121f4eaR1-R5) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R122)