### PR TITLE
Add email report permission for observers and remove PM

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,7 +9,7 @@ class Ability
 
     elsif user.has_role? :observer
       can :read, :all
-      can %i[generate report cease_fire_report breach_report user_report], :report
+      can %i[generate report cease_fire_report email_report user_report breach_report user_report], :report
       can %i[add_status add_status update_issue_type update_due_date update_priority index_home all_tickets], Ticket
       can :manage, Issue, user_id: user.id
 

--- a/app/views/data_center/cease_fire_report.html.erb
+++ b/app/views/data_center/cease_fire_report.html.erb
@@ -123,7 +123,7 @@
       <%= form_with url: cease_fire_report_path, method: :get, local: true do |f| %>
         <%= f.submit "Clear", class: 'bg-gray-500 hover:bg-gray-700 p-2 rounded font-bold rounded-lg text-slate-100' %>
       <% end %>
-      <% if current_user.has_role?(:admin) or current_user.has_role?('project manager') or current_user.has_role?(:observer) %>
+      <% if current_user.has_role?(:admin) or current_user.has_role?(:observer) %>
         <% if @clients.present? && @clients.first.present? %>
           <%= link_to "Send To CEO",
                       email_report_path(client_id: @clients.first.id),


### PR DESCRIPTION
This pull request introduces changes to refine user permissions and adjust role-based access in the application. The key updates include modifying permissions for the `observer` role and simplifying the visibility logic for certain UI elements.

### User Permissions Updates:
* [`app/models/ability.rb`](diffhunk://#diff-0fdc2ce2595c4fe479d6a97b404013651e8a0e2d4b02d93c87843b3a30103d9fL12-R12): Updated the `observer` role to include the `email_report` action in its permissions for reports. This ensures observers can now send email reports.

### UI Logic Adjustments:
* [`app/views/data_center/cease_fire_report.html.erb`](diffhunk://#diff-413ef0b0ccf29cf8ad0c2dae1da8e1b6bdfcd6656d3eede0a1db94ee98b1cc5eL126-R126): Simplified the conditional logic for displaying the "Send To CEO" link by removing the `project manager` role from the allowed roles. Only `admin` and `observer` roles can now access this link.