### PR TITLE
Remove required attribute from name and email fields

### DIFF
--- a/app/views/client/edit.html.erb
+++ b/app/views/client/edit.html.erb
@@ -2,11 +2,11 @@
   <div class="grid grid-cols-2 gap-2">
     <div class="relative z-0 w-full mb-6 group">
       <%= f.label :name, ('Name *'), class: "capitalize block mb-1 text-sm font-medium text-gray-900 dark:text-white"  %><br />
-      <%= f.text_field :name, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '', required: true %>
+      <%= f.text_field :name, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
     </div>
     <div class="relative z-0 w-full mb-6 group">
       <%= f.label :email, ('Email *'), class: "capitalize block mb-1 text-sm font-medium"  %><br />
-      <%= f.email_field :email, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '', required: true %>
+      <%= f.email_field :email, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
     </div>
   </div>
   <div class="grid grid-cols-2 gap-2">


### PR DESCRIPTION
The `required` attribute was removed from the name and email fields in the client edit form. This allows greater flexibility in form submissions and delegates validation handling to the backend or other mechanisms.

This pull request makes a minor change to the `app/views/client/edit.html.erb` file by removing the `required: true` attribute from the `name` and `email` fields in the form. 

This change affects the following fields:

* `name` field: Removed the `required: true` attribute from the `f.text_field` helper.
* `email` field: Removed the `required: true` attribute from the `f.email_field` helper.