### PR TITLE
Remove redundant font-bold and capitalize classes

### DIFF
--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -54,7 +54,7 @@
               <%= @ticket.subject %>
             </span>
           </div>
-          <div class="mb-2.5 font-bold capitalize flex flex-wrap ">Content:
+          <div class="mb-2.5 flex flex-wrap ">Content:
             <% if @ticket.content.present? %>
               <span class="break-words overflow-hidden">
                 <%= raw @ticket.content.to_trix_html.gsub(/\[.*?\]/, '').strip %>


### PR DESCRIPTION
The `font-bold` and `capitalize` classes were unnecessary for the "Content" label and have been removed to simplify the code and styling. This change enhances maintainability without altering the UI appearance.

This pull request includes a minor update to the `app/views/tickets/show.html.erb` file. The change removes the `font-bold capitalize` classes from the `<div>` element displaying the ticket content.

Styling adjustment:

* [`app/views/tickets/show.html.erb`](diffhunk://#diff-99e200cfd1003b33f0a45daca511786346c2f5d376596d8c5aabdaf18052cc2dL57-R57): Removed the `font-bold capitalize` classes from the `<div>` element to adjust the styling of the "Content" label.