### PR TITLE
Refactor CEO role redirection logic in `ApplicationController`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,11 +36,9 @@ class ApplicationController < ActionController::Base
     return unless controller_name == 'registrations' && action_name == 'update' && params[:user].present?
     return unless current_user.update(first_login: true, first_name: params[:user][:first_name], last_name: params[:user][:last_name])
 
-    if user_signed_in? && current_user.has_role?(:ceo) && !request.path.start_with?(cease_fire_report_path)
-      redirect_to cease_fire_report_path
-    else
-      redirect_to root_path, alert: 'Profile is Updated.' and return
-    end
+    return redirect_to root_path, alert: 'Profile is Updated.' unless user_signed_in? && current_user.has_role?(:ceo) && !request.path.start_with?(cease_fire_report_path)
+
+    redirect_to cease_fire_report_path
   end
 
   def load_notifications

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,11 +36,11 @@ class ApplicationController < ActionController::Base
     return unless controller_name == 'registrations' && action_name == 'update' && params[:user].present?
     return unless current_user.update(first_login: true, first_name: params[:user][:first_name], last_name: params[:user][:last_name])
 
-    redirect_to root_path, alert: 'Profile is Updated.' and return
-
-    return unless user_signed_in? && current_user.has_role?(:ceo) && !request.path.start_with?(cease_fire_report_path)
-
-    redirect_to cease_fire_report_path
+    if user_signed_in? && current_user.has_role?(:ceo) && !request.path.start_with?(cease_fire_report_path)
+      redirect_to cease_fire_report_path
+    else
+      redirect_to root_path, alert: 'Profile is Updated.' and return
+    end
   end
 
   def load_notifications


### PR DESCRIPTION
This pull request refactors the `check_user_state` method in `app/controllers/application_controller.rb` to improve readability and ensure consistent redirection logic based on user roles and conditions.

### Changes to redirection logic:
* Reorganized the logic to prioritize checking if the user is signed in, has the CEO role, and is not on the cease-fire report path. If these conditions are met, the user is redirected to the cease-fire report path. Otherwise, the user is redirected to the root path with an alert message.