### PR TITLE
Refactor CEO-specific logic in views and controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,12 +47,6 @@ class ApplicationController < ActionController::Base
     @notifications = current_user.notifications.order(created_at: :desc)
   end
 
-  # def redirect_based_on_role
-  #  return unless user_signed_in? && current_user.has_role?(:ceo) && !request.path.start_with?(cease_fire_report_path)
-
-  #  redirect_to cease_fire_report_path
-  # end
-
   def redirect_to_root
     redirect_to root_path, alert: 'The page you were looking for does not exist.'
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,154 +1,159 @@
 class HomeController < ApplicationController
   before_action :authenticate_user!
   def index
-    @users = User.all.order('created_at DESC')
-    # Count the number of issues created by the current user per project
-    @issues_count_per_project_for_current_user = current_user.projects # Get all projects the current user is a member
-      .joins(tickets: :issues) # Join the projects, tickets, and issues tables
-      .where('issues.user_id = ?', current_user.id) # Only count issues by the current user
-      .group('projects.title') # Group the results by project title
-      .count('issues.id') # Count the total number of issues created by the current user for each project
+    if user_signed_in? && current_user.has_role?(:ceo)
+      redirect_to cease_fire_report_path
+    else
+      # normal home page logic
+      @users = User.all.order('created_at DESC')
+      # Count the number of issues created by the current user per project
+      @issues_count_per_project_for_current_user = current_user.projects # Get all projects the current user is a member
+        .joins(tickets: :issues) # Join the projects, tickets, and issues tables
+        .where('issues.user_id = ?', current_user.id) # Only count issues by the current user
+        .group('projects.title') # Group the results by project title
+        .count('issues.id') # Count the total number of issues created by the current user for each project
 
-    # Count the total number of tickets created for each project (by anyone)
-    @tickets_count_per_project = current_user.projects # Get all projects the current user is a member of
-      .joins(:tickets) # Join the projects and tickets tables
-      .group('projects.title') # Group the results by project title
-      .count('tickets.id') # Count the total number of tickets created for each project
+      # Count the total number of tickets created for each project (by anyone)
+      @tickets_count_per_project = current_user.projects # Get all projects the current user is a member of
+        .joins(:tickets) # Join the projects and tickets tables
+        .group('projects.title') # Group the results by project title
+        .count('tickets.id') # Count the total number of tickets created for each project
 
-    # Count the total number of issues created for each project (by anyone)
-    @issues_count_per_project = current_user.projects # Get all projects the current user is a member of
-      .joins(tickets: :issues) # Join the projects, tickets, and issues tables
-      .group('projects.title') # Group the results by project title
-      .count('issues.id') # Count the total number of issues created for each project
+      # Count the total number of issues created for each project (by anyone)
+      @issues_count_per_project = current_user.projects # Get all projects the current user is a member of
+        .joins(tickets: :issues) # Join the projects, tickets, and issues tables
+        .group('projects.title') # Group the results by project title
+        .count('issues.id') # Count the total number of issues created for each project
 
-    # Count the total number of tickets created by the current user for each project
-    @tickets_count_per_project_for_current_user = current_user.projects # Get all projects the current user is a member
-      .joins(:tickets) # Join the projects and tickets tables
-      .where('tickets.user_id = ?', current_user.id) # Only count tickets by the current user
-      .group('projects.title') # Group the results by project title
-      .count('tickets.id') # Count the total number of tickets created by the current user for each project
+      # Count the total number of tickets created by the current user for each project
+      @tickets_count_per_project_for_current_user = current_user.projects # Get all projects the current user is a member
+        .joins(:tickets) # Join the projects and tickets tables
+        .where('tickets.user_id = ?', current_user.id) # Only count tickets by the current user
+        .group('projects.title') # Group the results by project title
+        .count('tickets.id') # Count the total number of tickets created by the current user for each project
 
-    # Count the total number of tickets created by the current user for each project
-    @issues_count_per_project_for_current_user = current_user.projects # Get all projects the current user is a member
-      .joins(tickets: :issues) # Join the projects, tickets, and issues tables
-      .where('issues.user_id = ?', current_user.id) # Only count issues by the current user
-      .group('projects.title') # Group the results by project title
-      .count('issues.id') # Count the total number of issues created by the current user for each project
+      # Count the total number of tickets created by the current user for each project
+      @issues_count_per_project_for_current_user = current_user.projects # Get all projects the current user is a member
+        .joins(tickets: :issues) # Join the projects, tickets, and issues tables
+        .where('issues.user_id = ?', current_user.id) # Only count issues by the current user
+        .group('projects.title') # Group the results by project title
+        .count('issues.id') # Count the total number of issues created by the current user for each project
 
-    # Count the total number of tickets created for each project (by anyone)
-    @tickets_count_per_project = current_user.projects # Get all projects the current user is a member of
-      .joins(:tickets) # Join the projects and tickets tables
-      .group('projects.title') # Group the results by project title
-      .count('tickets.id') # Count the total number of tickets created for each project
+      # Count the total number of tickets created for each project (by anyone)
+      @tickets_count_per_project = current_user.projects # Get all projects the current user is a member of
+        .joins(:tickets) # Join the projects and tickets tables
+        .group('projects.title') # Group the results by project title
+        .count('tickets.id') # Count the total number of tickets created for each project
 
-    # Count the total number of issues created for each project (by anyone)
-    @issues_count_per_project = current_user.projects # Get all projects the current user is a member of
-      .joins(tickets: :issues) # Join the projects, tickets, and issues tables
-      .group('projects.title') # Group the results by project title
-      .count(' issues.id') # Count the total number of issues created for each project
+      # Count the total number of issues created for each project (by anyone)
+      @issues_count_per_project = current_user.projects # Get all projects the current user is a member of
+        .joins(tickets: :issues) # Join the projects, tickets, and issues tables
+        .group('projects.title') # Group the results by project title
+        .count(' issues.id') # Count the total number of issues created for each project
 
-    # @status_data = current_user.projects.joins(tickets: :statuses).group('statuses.name').count
+      # @status_data = current_user.projects.joins(tickets: :statuses).group('statuses.name').count
 
-    @status_data = current_user.projects.joins(tickets: :statuses).group('statuses.name').count
-    @total_tickets = @status_data.values.sum
-    # @status_data['Total'] = @total_tickets # to make it appear at the far right
-    @status_data = { 'Total' => @total_tickets }.merge(@status_data)
+      @status_data = current_user.projects.joins(tickets: :statuses).group('statuses.name').count
+      @total_tickets = @status_data.values.sum
+      # @status_data['Total'] = @total_tickets # to make it appear at the far right
+      @status_data = { 'Total' => @total_tickets }.merge(@status_data)
 
-    @status_per_project = current_user.projects.joins(tickets: :statuses).group('projects.title', 'statuses.name').count
+      @status_per_project = current_user.projects.joins(tickets: :statuses).group('projects.title', 'statuses.name').count
 
-    @total_tickets_per_project = current_user.projects
-      .joins(:tickets)
-      .group('projects.title')
-      .count('tickets.id')
+      @total_tickets_per_project = current_user.projects
+        .joins(:tickets)
+        .group('projects.title')
+        .count('tickets.id')
 
-    # Calculate the total number of tickets for all projects
-    total_tickets = @total_tickets_per_project.values.sum
+      # Calculate the total number of tickets for all projects
+      total_tickets = @total_tickets_per_project.values.sum
 
-    # Create a new hash with "All Projects" as the first entry
-    @total_tickets_per_project = { 'All Projects' => total_tickets }.merge(@total_tickets_per_project)
+      # Create a new hash with "All Projects" as the first entry
+      @total_tickets_per_project = { 'All Projects' => total_tickets }.merge(@total_tickets_per_project)
 
-    # Filter and group tickets by "closed" and "reopened" statuses
-    @closed_and_reopened_tickets = current_user.projects.joins(tickets: :statuses).group('statuses.name').count
-    @closed_and_reopened_tickets = { 'Closed' => @closed_and_reopened_tickets['Closed'] || 0,
-                                     'Reopened' => @closed_and_reopened_tickets['Reopened'] || 0 }
-    # Total ticket counts
-    @closed_and_reopened_tickets = { 'All Tickets' => total_tickets }.merge(@closed_and_reopened_tickets)
+      # Filter and group tickets by "closed" and "reopened" statuses
+      @closed_and_reopened_tickets = current_user.projects.joins(tickets: :statuses).group('statuses.name').count
+      @closed_and_reopened_tickets = { 'Closed' => @closed_and_reopened_tickets['Closed'] || 0,
+                                       'Reopened' => @closed_and_reopened_tickets['Reopened'] || 0 }
+      # Total ticket counts
+      @closed_and_reopened_tickets = { 'All Tickets' => total_tickets }.merge(@closed_and_reopened_tickets)
 
-    # Count the number of tickets created per day
-    @tickets = current_user.projects.joins(:tickets)
+      # Count the number of tickets created per day
+      @tickets = current_user.projects.joins(:tickets)
 
-    if params[:start_date].present? && params[:end_date].present?
-      @tickets = @tickets.where('tickets.created_at >= ? AND tickets.created_at <= ?', params[:start_date],
-                                params[:end_date])
-    end
+      if params[:start_date].present? && params[:end_date].present?
+        @tickets = @tickets.where('tickets.created_at >= ? AND tickets.created_at <= ?', params[:start_date],
+                                  params[:end_date])
+      end
 
-    grouping_period = params[:grouping_period] || 'day'
+      grouping_period = params[:grouping_period] || 'day'
 
-    @chart_data = case grouping_period
-                  when 'day'
-                    @tickets.group_by_day('tickets.created_at', time_zone: 'UTC', format: '%Y-%m-%d').count
-                  when 'month'
-                    @tickets.group_by_month('tickets.created_at').count
-                  when 'year'
-                    @tickets.group_by_year('tickets.created_at').count
-                  end
-
-    @total_tickets_per_project.values.sum
-
-    # Add a column graph with a search and filter feature that include users
-    # @chart_data_display
-
-    @tickets_user = Ticket.all
-
-    if params[:start_date].present? && params[:end_date].present?
-      @tickets_user = @tickets_user.where('tickets.created_at >= ? AND tickets.created_at <= ?', params[:start_date],
-                                          params[:end_date])
-    end
-
-    @tickets_user = if current_user.has_role?(:admin) && params[:user_id].present?
-                      @tickets_user.joins(:users).where(users: { id: params[:user_id] })
-                    else
-                      @tickets_user.joins(:users).where(users: { id: current_user.id })
+      @chart_data = case grouping_period
+                    when 'day'
+                      @tickets.group_by_day('tickets.created_at', time_zone: 'UTC', format: '%Y-%m-%d').count
+                    when 'month'
+                      @tickets.group_by_month('tickets.created_at').count
+                    when 'year'
+                      @tickets.group_by_year('tickets.created_at').count
                     end
 
-    @tickets_user = @tickets_user.joins(:project) # Ensure projects table is joined
+      @total_tickets_per_project.values.sum
 
-    grouping_period = params[:grouping_period] || 'day'
+      # Add a column graph with a search and filter feature that include users
+      # @chart_data_display
 
-    @chart_data_per_user = case grouping_period
-                           when 'day'
-                             @tickets_user.group("CONCAT(users.first_name, ' ', users.last_name)").group_by_day(
-                               'tickets.created_at', time_zone: 'UTC', format: '%Y-%m-%d'
-                             ).count
-                           when 'month'
-                             @tickets_user.group("CONCAT(users.first_name, ' ', users.last_name)").group_by_month('tickets.created_at').count
-                           when 'year'
-                             @tickets_user.group("CONCAT(users.first_name, ' ', users.last_name)").group_by_year('tickets.created_at').count
-                           end
+      @tickets_user = Ticket.all
 
-    @total_tickets_per_project = @tickets_user.group('projects.title').count('tickets.id')
-    @total_tickets_per_project.values.sum
+      if params[:start_date].present? && params[:end_date].present?
+        @tickets_user = @tickets_user.where('tickets.created_at >= ? AND tickets.created_at <= ?', params[:start_date],
+                                            params[:end_date])
+      end
 
-    # Visualise SLA breaches and ticket statuses through graphs per project
+      @tickets_user = if current_user.has_role?(:admin) && params[:user_id].present?
+                        @tickets_user.joins(:users).where(users: { id: params[:user_id] })
+                      else
+                        @tickets_user.joins(:users).where(users: { id: current_user.id })
+                      end
 
-    # Visualise SLA breaches and ticket statuses through graphs per project
-    @sla_breaches_per_project = current_user.projects
-      .joins(:tickets)
-      .joins('INNER JOIN sla_tickets ON sla_tickets.ticket_id = tickets.id')
-      .where("sla_tickets.sla_status = 'Breached'") # Assuming you have a way to define SLA breach
-      .group('projects.title')
-      .count
+      @tickets_user = @tickets_user.joins(:project) # Ensure projects table is joined
 
-    @non_breached_tickets_per_project = current_user.projects
-      .joins(:tickets)
-      .joins('LEFT JOIN sla_tickets ON sla_tickets.ticket_id = tickets.id')
-      .where("sla_tickets.sla_status = 'Not Breached' OR sla_tickets.ticket_id IS NULL") # Assuming you have a way to define SLA breach
-      .group('projects.title')
-      .count
+      grouping_period = params[:grouping_period] || 'day'
 
-    @ticket_statuses_per_project = current_user.projects
-      .joins(:tickets)
-      .group('projects.title', 'tickets.status')
-      .count
+      @chart_data_per_user = case grouping_period
+                             when 'day'
+                               @tickets_user.group("CONCAT(users.first_name, ' ', users.last_name)").group_by_day(
+                                 'tickets.created_at', time_zone: 'UTC', format: '%Y-%m-%d'
+                               ).count
+                             when 'month'
+                               @tickets_user.group("CONCAT(users.first_name, ' ', users.last_name)").group_by_month('tickets.created_at').count
+                             when 'year'
+                               @tickets_user.group("CONCAT(users.first_name, ' ', users.last_name)").group_by_year('tickets.created_at').count
+                             end
+
+      @total_tickets_per_project = @tickets_user.group('projects.title').count('tickets.id')
+      @total_tickets_per_project.values.sum
+
+      # Visualise SLA breaches and ticket statuses through graphs per project
+
+      # Visualise SLA breaches and ticket statuses through graphs per project
+      @sla_breaches_per_project = current_user.projects
+        .joins(:tickets)
+        .joins('INNER JOIN sla_tickets ON sla_tickets.ticket_id = tickets.id')
+        .where("sla_tickets.sla_status = 'Breached'") # Assuming you have a way to define SLA breach
+        .group('projects.title')
+        .count
+
+      @non_breached_tickets_per_project = current_user.projects
+        .joins(:tickets)
+        .joins('LEFT JOIN sla_tickets ON sla_tickets.ticket_id = tickets.id')
+        .where("sla_tickets.sla_status = 'Not Breached' OR sla_tickets.ticket_id IS NULL") # Assuming you have a way to define SLA breach
+        .group('projects.title')
+        .count
+
+      @ticket_statuses_per_project = current_user.projects
+        .joins(:tickets)
+        .group('projects.title', 'tickets.status')
+        .count
+    end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,7 +14,7 @@ class Ability
       can :manage, Issue, user_id: user.id
 
     elsif user.has_role? :ceo
-      can :generate, :report # allow ceo to do anything
+      can :generate, :report # allow ceo to do anything cept manage all
 
     elsif user.has_role?('project manager')
       can %i[read assign_user unassign_user add_team], Project

--- a/app/views/data_center/_ticket_cease.html.erb
+++ b/app/views/data_center/_ticket_cease.html.erb
@@ -2,7 +2,17 @@
   <div class="mx-auto mb-4 px-4 sm:px-6 lg:px-8 py-8">
     <h2 class="text-xl font-bold mb-4 text-center">
       Ticket Status Report as of <%= Time.now.strftime("%d/%b/%Y at %I:%M %p") %> for
-      <% if params[:client_ids].present? %>
+
+      <% if current_user.has_role?(:ceo) %>
+        <% ceo_clients = Client.joins(projects: :users).where(projects: { id: current_user.projects.ids }).distinct %>
+        <% if ceo_clients.count == 1 %>
+          <%= ceo_clients.first.name %>
+        <% elsif ceo_clients.count == 2 %>
+          <%= ceo_clients.map(&:name).join(' and ') %>
+        <% else %>
+          <%= ceo_clients.map(&:name).to_sentence %>
+        <% end %>
+      <% elsif params[:client_ids].present? %>
         <% selected_clients = Client.where(id: params[:client_ids]) %>
         <% if selected_clients.count == 1 %>
           <%= selected_clients.first.name %>
@@ -14,6 +24,7 @@
       <% else %>
         All Clients
       <% end %>
+
     </h2>
     <div class="grid grid-cols-3">
       <div class="col-span-2">
@@ -76,7 +87,9 @@
         <th class="border border-black px-4 py-2">Status Updated At</th>
         <th class="border border-black px-4 py-2">Last Comment Updated At</th>
         <th class="border border-black px-4 py-2">Due Date</th>
-        <th class="border border-black px-4 py-2">View</th>
+        <% if !current_user.has_role?(:ceo) %>
+          <th class="border border-black px-4 py-2">View</th>
+        <% end %>
 
       </tr>
       </thead>
@@ -128,9 +141,11 @@
           <td class="border border-black px-4 py-2"><%= ticket.add_statuses.order(updated_at: :desc).first&.updated_at&.strftime('%d/%b/%Y %I:%M:%S %p') || 'N/A' %></td>
           <td class="border border-black px-4 py-2"><%= ticket.issues.order(updated_at: :desc).first&.updated_at&.strftime('%d/%b/%Y %I:%M:%S %p') || 'N/A' %></td>
           <td class="border border-black px-4 py-2"><%= ticket.due_date&.strftime('%d/%b/%Y') || 'N/A' %></td>
-          <td class="border border-black px-4 py-2">
-            <%= link_to 'VIEW', project_ticket_path(ticket.project, ticket), target: "_blank", class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100' %>
-          </td>
+          <% if !current_user.has_role?(:ceo) %>
+            <td class="border border-black px-4 py-2">
+              <%= link_to 'VIEW', project_ticket_path(ticket.project, ticket), target: "_blank", class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100' %>
+            </td>
+          <% end %>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/data_center/cease_fire_report.html.erb
+++ b/app/views/data_center/cease_fire_report.html.erb
@@ -28,7 +28,7 @@
         <!-- Hidden Input to store multiple selected statuses -->
         <div id="selectedStatusesWrapper"></div>
       </div>
-
+      <% if !current_user.has_role?(:ceo) %>
       <div class="flex flex-col relative gap-2">
         <label for="searchClient" class="capitalize text-sm font-bold w-full align-middle pt-3">Client</label>
         <!-- Searchable Input -->
@@ -56,6 +56,7 @@
         <div id="selectedClientsWrapper"></div>
 
       </div>
+      <% end %>
 
 
       <div class="flex flex-col gap-2">


### PR DESCRIPTION
Streamlined logic for CEO role-based access and data presentation across controllers and views. Adjusted ticket status report to include CEO-specific conditions and restricted certain UI elements. Updated XLSX export functionality for CEO ticket reporting. Fixed minor formatting inconsistencies.

This pull request introduces functionality to tailor the `cease_fire_report` feature for users with the `:ceo` role, including custom filtering, reporting, and UI adjustments. Key changes include adding role-specific logic in the controller, updating permissions, and modifying the views to reflect the new behavior.

### Controller Updates:
* Enhanced the `cease_fire_report` action in `DataCenterController` to include specific logic for `:ceo` users, allowing them to filter tickets by date, priority, and status, and generate custom reports in XLSX format.

### Permissions Updates:
* Updated the `Ability` model to clarify that `:ceo` users can generate reports but do not have full management permissions.

### View Adjustments:
* Modified `_ticket_cease.html.erb` to display client names dynamically for `:ceo` users based on their associated projects and to hide the "View" column for `:ceo` users. [[1]](diffhunk://#diff-092f8dc60ae759e4753884a582f1a00c6447008a42be17074631bf1f3510e8b6L5-R15) [[2]](diffhunk://#diff-092f8dc60ae759e4753884a582f1a00c6447008a42be17074631bf1f3510e8b6R90-R92) [[3]](diffhunk://#diff-092f8dc60ae759e4753884a582f1a00c6447008a42be17074631bf1f3510e8b6R144-R148)
* Updated `cease_fire_report.html.erb` to hide the client search and selection fields for `:ceo` users, as their clients are determined automatically. [[1]](diffhunk://#diff-413ef0b0ccf29cf8ad0c2dae1da8e1b6bdfcd6656d3eede0a1db94ee98b1cc5eL31-R31) [[2]](diffhunk://#diff-413ef0b0ccf29cf8ad0c2dae1da8e1b6bdfcd6656d3eede0a1db94ee98b1cc5eR59)