### PR TITLE
Fix case sensitivity in ticket status filtering in `DataCenterControl…

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -11,7 +11,7 @@ class DataCenterController < ApplicationController
       @tickets = Ticket.joins(project: :client)
         .where(projects: { id: current_user.projects.ids })
         .joins(:statuses)
-        .where.not(statuses: { name: %w[closed resolved declined] })
+        .where.not(statuses: { name: %w[Closed Resolved Declined] })
 
       if params[:start_date].present? && params[:end_date].present?
         start_date = Date.parse(params[:start_date])


### PR DESCRIPTION
…ler`

This pull request includes a minor update to the `cease_fire_report` method in the `DataCenterController`. The change standardizes the casing of status names in the query to ensure consistency.

* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL14-R14): Updated the `where.not` clause to use capitalized status names (`Closed`, `Resolved`, `Declined`) instead of lowercase (`closed`, `resolved`, `declined`) for consistency and to avoid potential mismatches.