### PR TITLE
Adjust email sending logic to exclude users with the CEO role in `Pro…

### DIFF
--- a/app/controllers/project_controller.rb
+++ b/app/controllers/project_controller.rb
@@ -179,7 +179,9 @@ class ProjectController < ApplicationController
 
       # Send email to the newly assigned user
       assigned_user = user # Assuming the first user is the assigned user
-      UserMailer.assignment_email(user, @project, current_user, assigned_user).deliver_later
+      # if current user has role :ceo do not send email to the user
+
+      UserMailer.assignment_email(user, @project, current_user, assigned_user).deliver_later unless user.has_role?(:ceo)
       # @project.users.each do |project_user|
       #  next if project_user == current_user
 


### PR DESCRIPTION
…jectController`

This pull request modifies the `assign_user` method in `app/controllers/project_controller.rb` to prevent sending assignment emails to users with the `:ceo` role.

Key change:

* Updated `assign_user` logic to conditionally skip sending assignment emails if the user has the `:ceo` role. (`[app/controllers/project_controller.rbL182-R184](diffhunk://#diff-6144fd8daa15a8e75b5c187fdce2ebfebf35c4dd975fa9888f8f31fe89e0755fL182-R184)`)