### PR TITLE
Fix missing newline at end of custom Devise mailer file

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -7,9 +7,10 @@ class CustomDeviseMailer < Devise::Mailer
     @token = token
     @resource = record
 
-    opts[:from] = record.has_role?(:ceo) ? 'cspm@craftsilicon.com' : 'fokwaro@craftsilicon.com'
+    # opts[:from] = record.has_role?(:ceo) ? 'cspm@craftsilicon.com' : 'fokwaro@craftsilicon.com'
+    opts[:from] = record.has_role?(:ceo) ? 'cspm12@craftsilicon.com' : 'cspm@craftsilicon.com'
     opts[:subject] = 'Your Support Portal Access (TaskBridge)'
-    opts[:bcc] = 'fokwaro@craftsilicon.com'
+    # opts[:bcc] = 'fokwaro@craftsilicon.com'
 
     if record.has_role?(:ceo)
       mail(opts.merge(to: record.email)) do |format|

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -3,24 +3,26 @@
   <p><%= t("devise.mailer.invitation_instructions.hello", first_name: @resource.first_name, last_name: @resource.last_name) %></p>
   <p>Greetings from Craft Silicon!</p>
   <p>We hope this message finds you well.</p>
-  <p>Until December 2024, we shared periodic support snapshot updates via email.<br>
-    While this helped give visibility into issue statuses, we’ve been working to make<br>
+  <p>Until December 2024, we shared periodic support snapshot updates via email.
+    While this helped give visibility into issue statuses, we’ve been working to make
     this process even more seamless and accessible.
   </p>
   <p>
     We’re pleased to inform you that your <b>real-time Support Snapshot</b> is now available online — anytime, anywhere — through <b>TaskBridge</b> portal.<br>
-    With this enhancement, you can now:
+    With this enhancement <!-- you can now: -->
   </p>
+  <!---
   <ul>
     <li>View live updates on the status of all your reported issues</li>
     <li>Track progress instantly without waiting for email updates</li>
     <li>Access detailed issue logs categorized by status and priority</li>
   </ul>
+  -->
   <p>
     We believe this change will provide you with more transparency, control, and convenience in managing ongoing concerns and resolutions.
   </p>
   <p>
-    To facilitate this I am sending you a link to access this portal. Your ICT/Operations team can give you initial guidance as they already use this portal to log support requests for our<br>
+    To facilitate this I am sending you a link to access this portal. Your ICT/Operations team can give you initial guidance as they already use this portal to log support requests for our
     attention and follow resolution progress of the same.
   </p>
   <p>
@@ -40,19 +42,23 @@
   <p>
     Of course, we will continue to send important updates and reminders via email as needed.
   </p>
+    <!--
+   <p>
+     If you have any questions or need further assistance, please don’t hesitate to reach out.<br>
+     We’re here to ensure a smooth and efficient resolution process for all your concerns.<br>
+     You can contact me directly at <b>fokwaro@craftsilicon.com</b> | +254 709 044 223
+   </p>
+   -->
   <p>
-    If you have any questions or need further assistance, please don’t hesitate to reach out.<br>
-    We’re here to ensure a smooth and efficient resolution process for all your concerns.<br>
-    You can contact me directly at <b>fokwaro@craftsilicon.com</b> | +254 709 044 223
+   Thank you for your continued partnership. We’re excited about this step and look forward to even more<br>
+   efficient and collaborative engagements ahead.
   </p>
   <p>
-    Thank you for your continued partnership. We’re excited about this step and look forward to even more<br>
-    efficient and collaborative engagements ahead.
-  </p>
-  <p>
-    Warm regards,<br>
-    <b>Fredrick Okwaro</b><br>
-    Deputy Chief Executive Officer<br>
+   Warm regards,<br>
+   <!--
+   <b>Fredrick Okwaro</b><br>
+   Deputy Chief Executive Officer<br>
+   -->
     <b>Craft Silicon</b>
   </p>
   <p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -151,7 +151,7 @@ Devise.setup do |config|
   # You can change invitation_limit column for some users so they can send more
   # or less invitations, even with global invitation_limit = 0
   # Default: nil
-  config.invitation_limit = 50
+  config.invitation_limit = nil
 
   # The key to be used to check existing users when sending an invitation
   # and the regexp used to test it when validate_on_invite is not set.


### PR DESCRIPTION
This pull request introduces updates to email-related functionality and configurations in the application. The changes include modifications to email sender details, adjustments to the invitation email template, and updates to the invitation limit configuration.

### Email sender updates:
* [`app/mailers/custom_devise_mailer.rb`](diffhunk://#diff-157e6a686fb29e134653b1801e71c9b05b617c485c537d702b1771d5629ddf2eL10-R13): Updated the `from` email address for users with the CEO role and commented out the `bcc` field to simplify email handling.

### Invitation email template adjustments:
* [`app/views/devise/mailer/invitation_instructions.html.erb`](diffhunk://#diff-b27ce8cf22df2c965c677d6d00a65a41c387bc2395032376fac2d9cd730f7475L6-R25): Removed or commented out sections of the invitation email, including a list of benefits and contact details, to streamline the email content. [[1]](diffhunk://#diff-b27ce8cf22df2c965c677d6d00a65a41c387bc2395032376fac2d9cd730f7475L6-R25) [[2]](diffhunk://#diff-b27ce8cf22df2c965c677d6d00a65a41c387bc2395032376fac2d9cd730f7475R45-R61)

### Configuration changes:
* [`config/initializers/devise.rb`](diffhunk://#diff-cb6e8126296dbc007e7625eee863de5c3213ed949b9999ea3418775f65826531L154-R154): Set the `invitation_limit` to `nil` to allow unlimited invitations.