### PR TITLE
Qa removal

### DIFF
--- a/app/views/data_center/project_report.html.erb
+++ b/app/views/data_center/project_report.html.erb
@@ -73,7 +73,6 @@
         <th class="border border-gray-300 px-4 py-2">Under Development</th>
         <th class="border border-gray-300 px-4 py-2">On Hold</th>
         <th class="border border-gray-300 px-4 py-2">Client Confirmation Pending</th>
-        <th class="border border-gray-300 px-4 py-2">QA Testing</th>
         <th class="border border-gray-300 px-4 py-2">Awaiting Build</th>
         <th class="border border-gray-300 px-4 py-2">Initial Response Breaches</th>
         <th class="border border-gray-300 px-4 py-2">Target Response Breaches</th>
@@ -94,7 +93,6 @@
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Under Development'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['On-Hold'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Client Confirmation Pending'] || 0 %></td>
-          <td class="border border-gray-300 px-4 py-2"><%= ticket_data['QA Testing'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Awaiting Build'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= @sla_status[user.id] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= @sla_target_response_deadline[user.id] || 0 %></td>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  # config.mailer_sender = 'cspm@craftsilicon.com'
+  config.mailer_sender = 'cspm@craftsilicon.com'
 
 
   # Configure the class responsible to send e-mails.


### PR DESCRIPTION
This pull request includes changes to the `app/views/data_center/project_report.html.erb` file to remove references to the "QA Testing" column and updates the `config/initializers/devise.rb` file to enable the `mailer_sender` configuration.

### Changes to project report view:

* [`app/views/data_center/project_report.html.erb`](diffhunk://#diff-14f4fa09e361a49b230054ee86a377aa4183fd434735213a31085e85e36c9c05L76): Removed the "QA Testing" column from the table headers and corresponding data row to simplify the report structure. [[1]](diffhunk://#diff-14f4fa09e361a49b230054ee86a377aa4183fd434735213a31085e85e36c9c05L76) [[2]](diffhunk://#diff-14f4fa09e361a49b230054ee86a377aa4183fd434735213a31085e85e36c9c05L97)

### Configuration updates:

* [`config/initializers/devise.rb`](diffhunk://#diff-cb6e8126296dbc007e7625eee863de5c3213ed949b9999ea3418775f65826531L27-R27): Enabled the `mailer_sender` configuration by uncommenting and setting the email address to `cspm@craftsilicon.com`.