### PR TITLE
Refactor ticket chart data to exclude specific statuses and filter ou…

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -222,8 +222,17 @@ class DataCenterController < ApplicationController
       end
 
       # Prepare data for the pie chart
-      @tickets_chart_data = @organized_tickets.transform_keys { |id| User.find(id).name }
-      @tickets_chart_data = @tickets_chart_data.transform_values { |data| data[:total] }
+      # @tickets_chart_data = @organized_tickets.transform_keys { |id| User.find(id).name }
+      # @tickets_chart_data = @tickets_chart_data.transform_values { |data| data[:total] }
+
+      excluded_statuses = %w[Closed Resolved Declined]
+      @tickets_chart_data = @organized_tickets.transform_values do |data|
+        # Remove excluded statuses and sum the rest
+        filtered = data.reject { |k, _| excluded_statuses.include?(k) || k == :total }
+        filtered.values.sum
+      end.transform_keys { |id| User.find(id).name }
+      @tickets_chart_data = @tickets_chart_data.reject { |_, count| count.zero? }
+
       @tickets_per_project = @tickets.group('projects.title').count
 
       respond_to do |format|

--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -226,13 +226,11 @@ class DataCenterController < ApplicationController
       # @tickets_chart_data = @tickets_chart_data.transform_values { |data| data[:total] }
 
       excluded_statuses = %w[Closed Resolved Declined]
-      @tickets_chart_data = @organized_tickets.transform_values do |data|
-        # Remove excluded statuses and sum the rest
+      filtered_chart_data = @organized_tickets.transform_values do |data|
         filtered = data.reject { |k, _| excluded_statuses.include?(k) || k == :total }
         filtered.values.sum
-      end.transform_keys { |id| User.find(id).name }
-      @tickets_chart_data = @tickets_chart_data.reject { |_, count| count.zero? }
-
+      end
+      @tickets_chart_data = filtered_chart_data.transform_keys { |id| User.find(id).name }
       @tickets_per_project = @tickets.group('projects.title').count
 
       respond_to do |format|

--- a/app/views/data_center/project_report.html.erb
+++ b/app/views/data_center/project_report.html.erb
@@ -68,6 +68,7 @@
       <tr>
         <th class="border border-gray-300 px-4 py-2">User Name</th>
         <th class="border border-gray-300 px-4 py-2">Total Assigned Tickets</th>
+        <th class="border border-gray-300 px-4 py-2">Total Open Tickets</th>
         <th class="border border-gray-300 px-4 py-2">Assigned</th>
         <th class="border border-gray-300 px-4 py-2">Work in Progress</th>
         <th class="border border-gray-300 px-4 py-2">Under Development</th>
@@ -88,6 +89,7 @@
         <tr>
           <td class="border border-gray-300 px-4 py-2"><%= user.name %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data[:total] || 0 %></td>
+          <td class="border border-gray-300 px-4 py-2"><%= @tickets_chart_data[user.name] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Assigned'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Work in Progress'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Under Development'] || 0 %></td>


### PR DESCRIPTION
…t zero counts.
This pull request updates the `project_report` method in `app/controllers/data_center_controller.rb` to refine the data preparation for the pie chart by excluding certain ticket statuses and ensuring more accurate aggregation.

### Changes to pie chart data preparation:

* Updated the logic for `@tickets_chart_data` to exclude tickets with statuses `Closed`, `Resolved`, and `Declined`, as well as the `:total` key, ensuring only relevant statuses are included in the aggregation.
* Added a filter to remove users with zero tickets from the resulting chart data, improving the clarity of the pie chart.