### PR TITLE
Order tickets by creation date in addition to project title for consi…

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -257,12 +257,12 @@ class DataCenterController < ApplicationController
       @tickets = Ticket.joins(:statuses, :taggings, :project)
         .where.not(statuses: { name: %w[Resolved Closed Declined] })
         .where(taggings: { user_id: @user.id })
-        .order('projects.title')
+        .order('projects.title').order('created_at DESC')
     else
       @tickets_by_user = Ticket.joins(:statuses, :taggings, :project)
         .where.not(statuses: { name: %w[Resolved Closed Declined] })
         .where(taggings: { user_id: @team.users.pluck(:id) })
-        .order('projects.title')
+        .order('projects.title').order('created_at DESC')
         .group_by(&:user)
     end
   end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -397,6 +397,7 @@ class TicketsController < ApplicationController
     @tickets = Ticket.joins(:statuses, :project)
       .where(projects: { id: @projects.ids })
       .where.not(statuses: { name: %w[Closed Resolved Declined] })
+      .order('created_at DESC')
       .distinct
     @per_page = 20
     @page = (params[:page] || 1).to_i


### PR DESCRIPTION
…stent sorting.

This pull request updates the `assigned_tickets` method in `app/controllers/data_center_controller.rb` to improve the sorting of tickets by adding a secondary sort criterion based on creation date.

Sorting improvements:

* Updated the `assigned_tickets` method to sort tickets first by `projects.title` and then by `created_at` in descending order for both individual user tickets and team tickets.