### PR TITLE
Fix create_ticket_email call to remove redundant parameter in change …

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -125,7 +125,7 @@ class TicketsController < ApplicationController
         # Send notification email to assigned user
         assigned_user = @project.user
         if @ticket.issue == 'CHANGE REQUEST'
-          UserMailer.create_ticket_email(@ticket, current_user, 'change@craftsilicon.com', assigned_user, @project).deliver_later
+          UserMailer.create_ticket_email(@ticket, current_user, 'change@craftsilicon.com',@project).deliver_later
         elsif assigned_user.present?
           UserMailer.create_ticket_email(@ticket, current_user, assigned_user, @project).deliver_later
         else

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -125,7 +125,7 @@ class TicketsController < ApplicationController
         # Send notification email to assigned user
         assigned_user = @project.user
         if @ticket.issue == 'CHANGE REQUEST'
-          UserMailer.create_ticket_email(@ticket, current_user, 'change@craftsilicon.com',@project).deliver_later
+          UserMailer.create_ticket_email(@ticket, current_user, 'change@craftsilicon.com', @project).deliver_later
         elsif assigned_user.present?
           UserMailer.create_ticket_email(@ticket, current_user, assigned_user, @project).deliver_later
         else


### PR DESCRIPTION
…request case.
This pull request includes a minor update to the `create` method in `tickets_controller.rb`. The change simplifies the parameters passed to the `UserMailer.create_ticket_email` method for 'CHANGE REQUEST' tickets by removing the `assigned_user` parameter, as it is no longer required.

* [`app/controllers/tickets_controller.rb`](diffhunk://#diff-d4c5ab3656241a42b628137d4f0e84e6fbaa7bb928bc4569b9cfe442a583ffcdL128-R128): Updated the `create` method to remove the `assigned_user` parameter when sending notification emails for 'CHANGE REQUEST' tickets.