### PR TITLE
Remove commented out ERB code in the devise/invitation_instructions file

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -11,13 +11,6 @@
     We’re pleased to inform you that your <b>real-time Support Snapshot</b> is now available online — anytime, anywhere — through <b>TaskBridge</b> portal.<br>
     With this enhancement <!-- you can now: -->
   </p>
-  <!---
-  <ul>
-    <li>View live updates on the status of all your reported issues</li>
-    <li>Track progress instantly without waiting for email updates</li>
-    <li>Access detailed issue logs categorized by status and priority</li>
-  </ul>
-  -->
   <p>
     We believe this change will provide you with more transparency, control, and convenience in managing ongoing concerns and resolutions.
   </p>
@@ -42,23 +35,12 @@
   <p>
     Of course, we will continue to send important updates and reminders via email as needed.
   </p>
-    <!--
-   <p>
-     If you have any questions or need further assistance, please don’t hesitate to reach out.<br>
-     We’re here to ensure a smooth and efficient resolution process for all your concerns.<br>
-     You can contact me directly at <b>fokwaro@craftsilicon.com</b> | +254 709 044 223
-   </p>
-   -->
   <p>
    Thank you for your continued partnership. We’re excited about this step and look forward to even more<br>
    efficient and collaborative engagements ahead.
   </p>
   <p>
    Warm regards,<br>
-   <!--
-   <b>Fredrick Okwaro</b><br>
-   Deputy Chief Executive Officer<br>
-   -->
     <b>Craft Silicon</b>
   </p>
   <p>


### PR DESCRIPTION
# Hello @ger619  :wave: 

This PR removes commented out erb code from the devise/mailer/invitation_instructions.erb file cleaning up the code in the file making it neater and more maintainable.

**Thank you for having a look at the changes pushed. :pray:**