### PR TITLE
Add dynamic page titles for all pages found on Taskbridge

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,12 +31,12 @@ module ApplicationHelper
   end
 
   def full_title(page_title = '')
-    base_title = "Taskbridge"
+    base_title = 'Taskbridge'
 
-    unless page_title.empty?
-      "#{base_title} | #{page_title}"
-    else
+    if page_title.empty?
       base_title
+    else
+      "#{base_title} | #{page_title}"
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,4 +29,14 @@ module ApplicationHelper
   def previewable?(attachment)
     attachment.content_type.start_with?('image/')
   end
+
+  def full_title(page_title = '')
+    base_title = "Taskbridge"
+
+    unless page_title.empty?
+      "#{base_title} | #{page_title}"
+    else
+      base_title
+    end
+  end
 end

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -1,1 +1,3 @@
+<% provide(:title, "New Project Status for: #{@product.name}") %>
+
 <%= render 'boards/form' %>

--- a/app/views/bugs/edit.html.erb
+++ b/app/views/bugs/edit.html.erb
@@ -1,1 +1,3 @@
+<% provide(:title, "Edit bug for: #{@defect.name}") %>
+
 <%= render 'edit_form', defect: @defect %>

--- a/app/views/bugs/new.html.erb
+++ b/app/views/bugs/new.html.erb
@@ -1,1 +1,3 @@
+<% provide(:title, "New bug for: #{@defect.name}") %>
+
 <%= render 'form', defect: @defect %>

--- a/app/views/client/edit.html.erb
+++ b/app/views/client/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Edit Client Details: #{@client.name}") %>
+
 <%= form_with  model: @client, url: client_path(@client), method: :patch do |f| %>
   <div class="grid grid-cols-2 gap-2">
     <div class="relative z-0 w-full mb-6 group">

--- a/app/views/client/index.html.erb
+++ b/app/views/client/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "All Clients") %>
+
 <%= render 'client/top_bar_clients' %>
 <%= render 'client/client' %>
 <div class="flex gap-10 mt-5">

--- a/app/views/client/new.html.erb
+++ b/app/views/client/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "New Client Record") %>
+
 <%= form_with  model: @client, url: client_index_url, method: :post, data: { turbo: false }, local: true do |f| %>
   <div class="grid grid-cols-2 gap-2">
     <div class="relative z-0 w-full mb-6 group">

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "SLA Report") %>
+
 <div class="mx-auto mb-6 p-6">
   <div class="flex justify-between items-center">
     <div class="relative w-80">

--- a/app/views/data_center/breach_report.html.erb
+++ b/app/views/data_center/breach_report.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Breach Report") %>
+
 <h1 class="flex justify-center text-xl font-bold mb-4">Breach Report</h1>
 
 <div class="p-2 w-full mx-auto">

--- a/app/views/data_center/cbk_groupware_report.html.erb
+++ b/app/views/data_center/cbk_groupware_report.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "CBK Report") %>
+
 <%= form_with url: cbk_groupware_report_path, method: :get, local: true, class: "space-y-4" do %>
   <div class="flex flex-wrap gap-4 justify-center">
     <div class="field">

--- a/app/views/data_center/cease_fire_report.html.erb
+++ b/app/views/data_center/cease_fire_report.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Tickets Status") %>
+
 <h1 class="flex justify-center text-2xl font-bold mb-4">
   <% if current_user.has_role?(:admin) or current_user.has_role?('project manager') %>
     Cease Fire Report

--- a/app/views/data_center/orm_report.html.erb
+++ b/app/views/data_center/orm_report.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "ORM Report") %>
+
 <!-- app/views/data_center/orm_report.html.erb -->
 
 <h1 class="flex justify-center text-2xl font-bold mb-4">ORM Report</h1>

--- a/app/views/data_center/orm_team_report.html.erb
+++ b/app/views/data_center/orm_team_report.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "ORM Team Report") %>
+
 <h1 class="flex justify-center text-2xl font-bold mb-4">ORM Teams Report</h1>
 <div class="p-2 w-full">
   <%= form_with url: orm_team_report_path, method: :get, local: true do |f| %>

--- a/app/views/data_center/project_report.html.erb
+++ b/app/views/data_center/project_report.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Workload Report") %>
+
 <h1 class="flex justify-center text-2xl font-bold mb-4">Workload Report<span>(Blank Start and End Date show you for th last 6 month)</span></h1>
 <div class="p-2 w-full">
   <%= form_with url: project_report_path, method: :get, local: true do %>

--- a/app/views/data_center/sod_report.html.erb
+++ b/app/views/data_center/sod_report.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Start and end of Day Report") %>
+
 <div class="mx-auto mb-4 px-4 sm:px-6 lg:px-8 py-8">
   <h2 class="text-xl font-bold mb-4 text-center capitalize">Start & End of Day Report</h2>
 

--- a/app/views/data_center/user_report.html.erb
+++ b/app/views/data_center/user_report.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Users Reports") %>
+
 <h1 class="flex justify-center text-2xl font-bold mb-4">User Report</h1>
 <div class="p-2 w-full">
   <%= form_with url: user_report_path, method: :get, local: true do |f| %>

--- a/app/views/defect/index.html.erb
+++ b/app/views/defect/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Quality Assurance") %>
+
 <!-- Topbar Section -->
 <div class="mb-4">
   <%= render 'defect/top_bar' %>

--- a/app/views/defect/new.html.erb
+++ b/app/views/defect/new.html.erb
@@ -1,1 +1,3 @@
+<% provide(:title, "New QA") %>
+
 <%= render 'defect/form' %>

--- a/app/views/defect/show.html.erb
+++ b/app/views/defect/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "QA Details for: #{@defect.name}") %>
+
 <div class="p-2">
   <!-- Topbar and Alert -->
   <%= render 'bugs/top_bug' %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Resend Confirmation Instructions") %>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: {turbo: false}) do |f| %>
   <section class="mx-auto pr-64 ">

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "  Create new user invitation") %>
+
 <% if current_user.has_role? :admin or current_user.has_role?('project manager') %>
   <h2><%= t "devise.invitations.new.header" %></h2>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Forgot Passowrd") %>
+
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, data: {turbo: false}) do |f| %>
   <section class="mx-auto pr-64 ">
       <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0 w-[600px]">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Sign Up") %>
+
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <section class="mx-auto pr-64">
   <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0 w-[600px]">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Sign in") %>
 <%= form_for(resource, as: resource_name, url: session_path(resource_name),  data: {turbo: false}) do |f| %>
 <section class="mx-auto pr-64 ">
   <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0 w-[600px]">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, "Sign in") %>
+<% provide(:title, "Sign In") %>
 <%= form_for(resource, as: resource_name, url: session_path(resource_name),  data: {turbo: false}) do |f| %>
 <section class="mx-auto pr-64 ">
   <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0 w-[600px]">

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Resend Unlock Instructions") %>
+
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post },data: {turbo: false}) do |f| %>
   <section class="mx-auto pr-64 ">
     <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0 w-[600px]">

--- a/app/views/groupwares/edit.html.erb
+++ b/app/views/groupwares/edit.html.erb
@@ -1,1 +1,3 @@
+<% provide(:title, "Edit CS sub product") %>
+
 <%= render 'groupwares/edit_form' %>

--- a/app/views/groupwares/new.html.erb
+++ b/app/views/groupwares/new.html.erb
@@ -1,1 +1,3 @@
+<% provide(:title, "Add new CS product") %>
+
 <%= render 'groupwares/form', software: @software %>

--- a/app/views/groupwares/show.html.erb
+++ b/app/views/groupwares/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Sub products for CS products: #{@software.name}") %>
+
 <div class="flex gap-2">
 Sub Product: <%= @groupware.name %>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Home") %>
+
 <div class="p-4 border-2 border-white rounded-lg flex flex-col items-center">
   <!-- Topbar Section  for admin and observer-->
   <% if current_user.has_role?(:admin) or current_user.has_role?(:observer) %>

--- a/app/views/issues/edit.html.erb
+++ b/app/views/issues/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Edit message for #{@current_user.name} for Ticket: #{@ticket.subject}") %>
+
 <%= render 'issues/new_back' %>
 
 <%= form_with(model: [@project, @ticket, @issue], method: :patch) do |f| %>

--- a/app/views/issues/new.html.erb
+++ b/app/views/issues/new.html.erb
@@ -1,2 +1,4 @@
+<% provide(:title, "New message for ticket: #{@ticket.subject}") %>
+
 <%= render 'issues/form', project: @project, ticket: @ticket %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Taskbridge</title>
+  <title><%= full_title(yield(:title)) %></title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>

--- a/app/views/location/index.html.erb
+++ b/app/views/location/index.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Location Details") %>
 
 <div class="overflow-x-auto shadow-md sm:rounded-lg w-[100%] ">
   <table class="w-full text-sm text-left rtl:text-right">

--- a/app/views/location/new.html.erb
+++ b/app/views/location/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Create new location") %>
+
 <%= form_with  model: @location, url: location_index_url, method: :post, data: { turbo: false }, local: true do |f| %>
   <div class="grid grid-cols-2 gap-2">
     <div class="relative z-0 w-full mb-6 group">

--- a/app/views/product/_added_users.html.erb
+++ b/app/views/product/_added_users.html.erb
@@ -1,12 +1,16 @@
-<h3>Assigned Agents</h3>
+<h3 class="font-bold pb-4">Assigned Agents</h3>
 <div class="flex flex-wrap gap-2">
-  <% @product.users.each do |user| %>
-    <p class="border-b-4 border-black border dark:border-slate-100 p-2 gap-4 text-xs rounded" >
-      <% if user.name.present? %>
-        <%= user.name %>
-      <% else %>
-        <%= truncate(user.email, length: 15, omission: '...') %>
-      <% end %>
-    </p>
+  <% unless !@product.users.any? %>
+    <% @product.users.each do |user| %>
+      <p class="border-b-4 border-black border dark:border-slate-100 p-2 gap-4 text-xs rounded" >
+        <% if user.name.present? %>
+          <%= user.name %>
+        <% else %>
+          <%= truncate(user.email, length: 15, omission: '...') %>
+        <% end %>
+      </p>
+    <% end %>
+  <% else %>
+    <p>This project does not have any assigned users/ agents. Kindly assign some and they will be listed here.</p>
   <% end %>
 </div>

--- a/app/views/product/edit.html.erb
+++ b/app/views/product/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Edit Project: #{@product.name}") %>
+
 <%= form_with model: @product, url: product_path(@product), method: :patch, local: true, data: { turbo: false } do |f| %>
   <% if @product.errors.any? %>
     <div class="mb-4 text-red-600">

--- a/app/views/product/index.html.erb
+++ b/app/views/product/index.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Projects") %>
 
 <%= render 'product/topbar_product' %>
 <%= render 'product/product_list' %>

--- a/app/views/product/new.html.erb
+++ b/app/views/product/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Create new Project") %>
+
 <%= form_with model: @product, url: product_index_url, method: :post, data: { turbo: false }, local: true do |f| %>
   <div class="md:gap-6">
     <div>

--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Project: #{@product.name}") %>
+
 <%= render 'boards/top_board' %>
 <div class="grid grid-cols-3 gap-4 mb-4 w-screen">
   <div class="p-4 items-center justify-center rounded col-span-1 border-r-2">

--- a/app/views/project/edit.html.erb
+++ b/app/views/project/edit.html.erb
@@ -1,3 +1,5 @@
+  <% provide(:title, "Edit Support Desk: #{@project.title}") %>
+
   <%= render 'project/new_back' %>
   <%= form_with  model: @project, url: project_path(@project), method: :patch do |f| %>
     <div class="md:gap-6">

--- a/app/views/project/index.html.erb
+++ b/app/views/project/index.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Support Desks") %>
 
   <!-- Topbar Section -->
   <div class="mb-4">

--- a/app/views/project/new.html.erb
+++ b/app/views/project/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Add Support Desk") %>
+
 <div class="grid grid-cols-2 ">
   <div class="grid col-span-1">
     <div class="flex gap-1">

--- a/app/views/project/show.html.erb
+++ b/app/views/project/show.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Support Desk: #{@project.title}") %>
 
 <%= render 'tickets/ticket_topbar' %>
 <div class="border-2 border-gray-200 rounded-lg dark:border-gray-700">

--- a/app/views/scripts/new.html.erb
+++ b/app/views/scripts/new.html.erb
@@ -1,1 +1,3 @@
+<% provide(:title, "New sub products for CS products") %>
+
 <%= render 'scripts/form' %>

--- a/app/views/software/edit.html.erb
+++ b/app/views/software/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Edit CS Product") %>
+
 <%= form_with  model: @software, url: software_path(@software), method: :patch do |f| %>
   <div class="relative z-0 w-full mb-6 group">
     <%= f.label :name, :Name, class: "capitalize block mb-1 text-sm font-medium text-gray-900 dark:text-white"  %><br />

--- a/app/views/software/index.html.erb
+++ b/app/views/software/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "CS Products") %>
+
 <%= render 'software/top_bar_software' %>
 <%= render 'software/software' %>
 <div class="flex gap-10 mt-5">

--- a/app/views/software/new.html.erb
+++ b/app/views/software/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "New CS Product") %>
+
 <%= form_with  model: @software, url: software_index_url, method: :post, data: { turbo: false }, local: true do |f| %>
   <div class="z-0 w-full mb-6 group">
     <%= f.label :name, ('Product Title'), class: "capitalize block mb-1 text-sm font-medium text-gray-900 dark:text-white"  %><br />

--- a/app/views/software/show.html.erb
+++ b/app/views/software/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "CS Product details for: #{@software.name}") %>
+
 <%= render 'groupwares/groupware_header' %>
 <%= @software.name %>
 <!-- Display groupware name -->

--- a/app/views/status/edit.html.erb
+++ b/app/views/status/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Edit Status") %>
+
 <%= form_with  model: @status, url: status_path(@status), method: :patch, local: true do |f| %>
   <div class="relative z-0 w-full mb-6 group">
     <%= f.label :name, :Name, class: "capitalize block mb-1 text-sm font-medium text-gray-900 dark:text-white"  %><br />

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Statuses") %>
+
 <%= render 'status/top_status' %>
 <%= render 'status/status_list' %>
 <!-- Pagination -->

--- a/app/views/status/new.html.erb
+++ b/app/views/status/new.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "New Status") %>
+
 <%= form_with  model: @status, url: status_index_url, method: :post, data: { turbo: false }, local: true do |f| %>
   <div class="relative z-0 w-full mb-6 group">
     <%= f.label :name, ('Name*'), class: "capitalize block mb-1 text-sm font-medium text-gray-900 dark:text-white"  %><br />

--- a/app/views/team/edit.html.erb
+++ b/app/views/team/edit.html.erb
@@ -1,1 +1,3 @@
+<% provide(:title, "Edit Team details for: #{@team.name}") %>
+
 <%= render 'team/edit_form' %>

--- a/app/views/team/index.html.erb
+++ b/app/views/team/index.html.erb
@@ -1,2 +1,4 @@
+<% provide(:title, "Teams") %>
+
 <%= render 'top_bar_team' %>
 <%= render 'team/team' %>

--- a/app/views/team/new.html.erb
+++ b/app/views/team/new.html.erb
@@ -1,1 +1,3 @@
+<% provide(:title, "New Team") %>
+
 <%= render 'team/form' %>

--- a/app/views/team/show.html.erb
+++ b/app/views/team/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Details for team: #{@team.name}") %>
+
 <div class="overflow-x-auto shadow-md sm:rounded-lg">
   <table class="w-full text-sm text-left rtl:text-right text-gray-900 dark:text-gray-400">
     <thead class="text-xs uppercase bg-gray-200 dark:bg-gray-700 dark:text-gray-400">

--- a/app/views/tickets/_form.html.erb
+++ b/app/views/tickets/_form.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "New Ticket for: #{@project.title}") %>
+
 <%= render 'tickets/new_back' %>
 <%= form_with(model: [project, project.tickets.build], data: { turbo: false }) do |f| %>
   <div class="relative overflow-x-auto shadow-md sm:rounded-lg w-[100%] p-1">

--- a/app/views/tickets/edit.html.erb
+++ b/app/views/tickets/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Edit ticket: #{@ticket.subject}") %>
+
 <%= render 'tickets/edit_form' %>
 
 

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Ticket: #{@ticket.subject} for Service Desk: #{@project.title}") %>
+
 <div class="p-2 container">
   <!-- Topbar and Alert -->
   <%= render 'issues/issue_topbar' %>

--- a/app/views/users/_user_list.html.erb
+++ b/app/views/users/_user_list.html.erb
@@ -30,7 +30,11 @@
     <% @users.each do |user| %>
       <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 h-12 text-center">
         <th scope="row" class="px-6 py-4 font-medium whitespace-nowrap capitalize text-left">
-          <%= link_to user.name, users_path(user.id) %>
+          <% if (can?(:manage, user) || (can?(:read, user) && !user.has_role?(:admin))) && user != current_user %>
+            <%= link_to user.name, edit_user_path(user), class: "text-slate-100 p-2 self-center text-center content-center" %>
+          <% else %>
+            <p><%= user.name %></p>
+          <% end %>
         </th>
 
         <td class="px-6 py-4 text-left">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, "Edit details for: #{@user.name}") %>
+
 <% if current_user.first_login == true %>
   <div class="mt-14 p-4 flex flex-col">
     <%= form_with model: @user, url: user_path(@user), method: :patch do |f| %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "Users details") %>
 
 <%= render partial: 'users/user_topbar' %>
 <%= render partial: 'users/user_list' %>


### PR DESCRIPTION
# Hello @ger619 :wave: 

This milestone implements dynamic page titles for all the pages that can be accessed in the Taskbridge platform. Instead of having a single static page title for all the pages, it was deemed to improve on user experience if all pages had dynamic page titles.

eg, Have a title for **TaskBridge | Sign In** instead of having only **Taskbridge** everywhere.

The implementation has a fall back to the original **Taskbridge** incase nopage title is provided. This PR works on this issue #884 

**Thank you for having a look at my PR :pray:**