### PR TITLE
Upload image and pdf in create task

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -113,7 +113,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:name, :topic, :description, :start_date, :end_date, :image, :board_id,
+    params.require(:task).permit(:name, :topic, :description, :start_date, :end_date, :image, :file, :board_id,
                                  :user_id)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,7 @@ class Task < ApplicationRecord
   belongs_to :product
   belongs_to :board
   has_one_attached :image
+  has_one_attached :file
   has_many :messages, dependent: :destroy
 
   resourcify

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -12,6 +12,8 @@ class Task < ApplicationRecord
   has_many :creators, -> { where(roles: { name: :creator }) }, class_name: 'User', through: :roles, source: :user
 
   validate :end_date_after_start_date
+  validate :image_must_be_an_image
+  validate :file_must_be_a_file
 
   has_many :add_tasks
   has_many :users, through: :add_tasks, dependent: :destroy
@@ -23,5 +25,23 @@ class Task < ApplicationRecord
     return unless end_date.present? && start_date.present? && end_date < start_date
 
     errors.add(:end_date, 'End Date must be greater than Start Date')
+  end
+
+  # Ensure uploaded image is an actual image
+  def image_must_be_an_image
+    return unless image.attached?
+
+    unless image.content_type.starts_with?("image/")
+      errors.add(:image, "must be an image file (jpeg, jpg, gif, or png).")
+    end
+  end
+
+  # Ensure uploaded file is a generic valid file
+  def file_must_be_a_file
+    return unless file.attached?
+
+    unless file.content_type.start_with?("application/") || file.content_type.start_with?("text/")
+      errors.add(:file, "must be a valid file (pdf, doc, txt, etc.).")
+    end
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -31,17 +31,17 @@ class Task < ApplicationRecord
   def image_must_be_an_image
     return unless image.attached?
 
-    unless image.content_type.starts_with?("image/")
-      errors.add(:image, "must be an image file (jpeg, jpg, gif, or png).")
-    end
+    return if image.content_type.starts_with?('image/')
+
+    errors.add(:image, 'must be an image file (jpeg, jpg, gif, or png).')
   end
 
   # Ensure uploaded file is a generic valid file
   def file_must_be_a_file
     return unless file.attached?
 
-    unless file.content_type.start_with?("application/") || file.content_type.start_with?("text/")
-      errors.add(:file, "must be a valid file (pdf, doc, txt, etc.).")
-    end
+    return if file.content_type.start_with?('application/') || file.content_type.start_with?('text/')
+
+    errors.add(:file, 'must be a valid file (pdf, doc, txt, etc.).')
   end
 end

--- a/app/views/tasks/_card.html.erb
+++ b/app/views/tasks/_card.html.erb
@@ -18,8 +18,10 @@
         Due Date: <%= task.end_date %>
       </h3>
       <div class="flex justify-center">
-        <% if task.image.present? %>
-          <%= image_tag(task.image, class: 'object-cover w-full max-w-xs h-auto rounded') %>
+        <% if task.image.attached? %>
+          <div class="mb-4">
+            <%= image_tag(task.image, class: 'object-cover w-full max-w-xs h-auto rounded') %>
+          </div>
         <% end %>
       </div>
         <h3 class="text-xs font-semibold">

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -19,12 +19,12 @@
 
       <div class="relative z-0 w-full mb-6 group">
         <%= f.label :image, ('Task Image (Only Images)'), class: "capitalize block mb-1 text-sm font-medium" %><br />
-        <%= f.file_field :image, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
+        <%= f.file_field :image, accept: 'image/*', class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
       </div>
 
       <div class="relative z-0 w-full mb-6 group">
         <%= f.label :file, ('Task File (Only files)'), class: "capitalize block mb-1 text-sm font-medium" %><br />
-        <%= f.file_field :file, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
+        <%= f.file_field :file, accept: '*/*', class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
       </div>
 
       <% new_board = Board.find_by(status: 'TO DO') %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -6,28 +6,27 @@
         &#8656; Back
       <% end %>
 
+      <div class="grid grid-cols-2 pt-8 gap-2">
+        <div class="relative z-0 w-full mb-6 group">
+          <%= f.label :name, ('Name*'), class: "capitalize block mb-1 text-sm font-medium" %><br />
+          <%= f.text_field :name, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '', required: true %>
+        </div>
+        <div class="relative z-0 w-full mb-6 group">
+          <%= f.label :topic, ('Topic*'), class: "capitalize block mb-1 text-sm font-medium" %><br />
+          <%= f.text_field :topic, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '', required: true %>
+        </div>
+      </div>
 
-      <div class="grid grid-cols-2 gap-2 mt-4">
       <div class="relative z-0 w-full mb-6 group">
-        <%= f.label :name, ('Name*'), class: "capitalize block mb-1 text-sm font-medium" %><br />
-        <%= f.text_field :name, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '', required: true %>
-      </div>
-      <div class="relative z-0 w-full mb-6 group">
-        <%= f.label :topic, ('Topic*'), class: "capitalize block mb-1 text-sm font-medium" %><br />
-        <%= f.text_field :topic, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '', required: true %>
-      </div>
-      <div class="relative z-0 w-full mb-6 group">
-        <%= f.label :description, 'Description*', class: "capitalize block mb-1 text-sm font-medium" %><br />
-        <%= f.text_area :description,
-          class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 resize-y",
-          placeholder: '',
-          required: true,
-          rows: 5 %>
-      </div>
-      <div class="relative z-0 w-full mb-6 group">
-        <%= f.label :image, ('Task Image'), class: "capitalize block mb-1 text-sm font-medium" %><br />
+        <%= f.label :image, ('Task Image (Only Images)'), class: "capitalize block mb-1 text-sm font-medium" %><br />
         <%= f.file_field :image, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
       </div>
+
+      <div class="relative z-0 w-full mb-6 group">
+        <%= f.label :file, ('Task File (Only files)'), class: "capitalize block mb-1 text-sm font-medium" %><br />
+        <%= f.file_field :file, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
+      </div>
+
       <% new_board = Board.find_by(status: 'TO DO') %>
       <%= f.hidden_field :board_id, value: new_board.id %>
     </div>
@@ -46,6 +45,16 @@
         <%= f.date_field :end_date, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '', required: true %>
       </div>
     </div>
+
+    <div class="relative z-0 w-full mb-6 group">
+      <%= f.label :description, 'Description*', class: "capitalize block mb-1 text-sm font-medium" %><br />
+      <%= f.rich_text_area :description,
+        class: "min-h-[300px] border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500 resize-y",
+        placeholder: '',
+        required: true,
+        rows: 5 %>
+    </div>
+
     <%= f.submit 'Add Task', class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
   </div>
 <% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -22,6 +22,10 @@
           <%= f.file_field :image, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
         </div>
         <div class="relative z-0 w-full mb-6 group">
+          <%= f.label :file, ('Task File'), class: "capitalize block mb-1 text-sm font-medium" %><br />
+          <%= f.file_field :file, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
+        </div>
+        <div class="relative z-0 w-full mb-6 group">
           <%= f.label :status, 'Board Status', class: "capitalize block mb-1 text-sm font-medium" %><br />
           <%= f.collection_select :board_id, @product.boards, :id, :status, {prompt: "Select Status"}, {class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", disabled: true} %>
         </div>
@@ -41,7 +45,7 @@
           <%= f.date_field :end_date, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '', required: true %>
         </div>
       </div>
-      <%= f.submit 'Add Task', class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
+      <%= f.submit 'Edit Task', class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>
     </div>
 
   <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -23,6 +23,10 @@
     <% if @task.image.present? %>
       <%= image_tag(@task.image, class: 'rounded object-cover w-full h-[400px]') %>
     <% end %>
+
+    <% if @task.file.present? %>
+      <%= link_to "Download #{@task.file.filename}", url_for(@task.file), target: "_blank", class: "text-blue-600 hover:underline" %>
+    <% end %>
     <div class="flex flex-row">
       <%= render 'tasks/add_task' %>
       <%= render 'tasks/add_state' %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -26,6 +26,9 @@
 
     <% if @task.file.present? %>
       <%= link_to "Download #{@task.file.filename}", url_for(@task.file), target: "_blank", class: "text-blue-600 hover:underline" %>
+
+    <% else %>
+      This task does not have an uploaded file. If you need to add a file, kindly <%= link_to "edit", edit_product_board_task_path(@product, @board, @task), method: :get, class: 'underline text-[#3F8CFF]' %> the task to include it.
     <% end %>
     <div class="flex flex-row">
       <%= render 'tasks/add_task' %>


### PR DESCRIPTION
Added support for downloading attached files from tasks. Users can now click a “View / Download” link to open files in a new browser tab, making it easier to review or save attachments.

Also, added the file upload separating the upload for an image and that one for a file type.