### PR TITLE
Add hover-based sidebar expand/collapse functionality for improved us…

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -325,6 +325,17 @@
       }
     });
 
+    sidebarMain.addEventListener("mouseenter", () => {
+      if (!isManuallyToggled) {
+        expandSidebar();
+      }
+    });
+
+    sidebarMain.addEventListener("mouseleave", () => {
+      if (!isManuallyToggled) {
+        collapseSidebar();
+      }
+    });
 
     function expandSidebar() {
       sidebarMain.classList.remove('w-12');


### PR DESCRIPTION
…er interaction.
This pull request adds hover-based functionality to the sidebar component, allowing it to automatically expand and collapse when the user hovers over it, provided it hasn't been manually toggled.

### Sidebar functionality enhancements:
* [`app/views/layouts/_sidebar.html.erb`](diffhunk://#diff-eeb99fbb736e7587a9ee1dc2af503b538ba6bd1f25221253475048adfb44bb47R328-R338): Added `mouseenter` and `mouseleave` event listeners to the sidebar. These listeners trigger the `expandSidebar` and `collapseSidebar` functions, respectively, unless the sidebar has been manually toggled.