### PR TITLE
Update products show page and add search select user

### DIFF
--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -79,11 +79,13 @@
         </ul>
       <% end %>
     </div>
+
+    <div class="col-span-1 pt-4">
+      <%= render 'product/added_users' %>
+    </div>
   </div>
   
-  <div class="col-span-1">
-    <%= render 'product/added_users' %>
-  </div>
+  
 
 </div>
 

--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -4,7 +4,7 @@
 <div class="grid grid-cols-3 gap-4 mb-4">
   <div class="p-4 items-center justify-center rounded col-span-1 border-r-2">
     <%= render 'layouts/alert' %>
-    <h1 class="text-xl">
+    <h1 class="text-md">
       Name of the Project: <%= @product.name %>
     </h1>
     <p class="capitalize text-sm text-balance">
@@ -29,7 +29,7 @@
   </div>
 
   <% if !@product_tasks_per_board_status.empty? %>
-    <div class="text-xl p-4 rounded border-r-2 ">
+    <div class="text-md p-4 rounded border-r-2 ">
       <h2>Product boards status Count for: <%= @product.name %></h2>
 
       <ul>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -49,12 +49,7 @@
           <%= @task.name %>
         </p>
       </div>
-      <div class="flex items-center">
-        <h4 class="block sm:mt-2 text-2xl font-semibold mr-2">
-          Description:
-        </h4>
-        <p class="mt-2 text-xl"><%= @task.description %></p>
-      </div>
+
       <div class="flex">
         <h5 class="block sm:mt-2 text-2xl font-semibold mr-2">
           Assignee:


### PR DESCRIPTION
# Hello @ger619  :wave: 

I implemented:

- [x] Remove the task description from the tasks show page. Users will see the task description from the products tasks page instead.
- [x] Change position of the assigned Agents from the bottom to the right under the date of the tasks
- [x] Update the visual of the products tasks reducing the font sizes to be visully appealing.