### PR TITLE
Update SOD report to send emails with user-specific tagged tickets; r…

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -446,8 +446,7 @@ class DataCenterController < ApplicationController
 
       user_ids = team.users.pluck(:id)
       base_scope = Ticket.joins(:users, project: :client)
-        .joins(:statuses)
-        .joins(:add_statuses)
+        .joins(:statuses, :add_statuses, :taggings)
         .where(users: { id: user_ids })
 
       tickets = if current_user.has_role?(:admin) || current_user.has_role?(:observer)
@@ -460,10 +459,9 @@ class DataCenterController < ApplicationController
                   tickets.where(statuses: { name: outstanding_statuses })
                     .where('add_statuses.updated_at >= ?', 24.hours.ago)
                 elsif report_type == 'eod'
-                  recently_updated_tickets = tickets
-                    .where(statuses: { name: outstanding_statuses })
+                  recently_updated = tickets.where(statuses: { name: outstanding_statuses })
                     .where('add_statuses.updated_at >= ?', 24.hours.ago)
-                  tickets.where.not(statuses: { name: outstanding_statuses }).or(recently_updated_tickets)
+                  tickets.where.not(statuses: { name: outstanding_statuses }).or(recently_updated)
                 else
                   tickets.where.not(statuses: { name: outstanding_statuses })
                 end.order('add_statuses.updated_at DESC')
@@ -471,10 +469,19 @@ class DataCenterController < ApplicationController
       mail_options = {}
       mail_options[:cc] = current_user.email if current_user.has_role?(:hod)
 
-      # Send the SOD report as an email (adjust mailer as needed)
+      # Send to each user only the tickets they are tagged on
       team.users.each do |user|
-        UserMailer.daily_ticket_email(user, tickets.to_a, mail_options).deliver_later
+        tagged_tickets = tickets
+          .select('tickets.*, add_statuses.updated_at') # Include order column
+          .joins(:taggings)
+          .where(taggings: { user_id: user.id })
+          .distinct
+
+        next if tagged_tickets.empty?
+
+        UserMailer.daily_ticket_email(user, tagged_tickets.to_a, mail_options).deliver_later
       end
+
       redirect_back fallback_location: root_path, notice: 'SOD report emailed successfully.'
     else
       redirect_back fallback_location: root_path, alert: 'Team not found.'

--- a/app/views/data_center/sod_report.html.erb
+++ b/app/views/data_center/sod_report.html.erb
@@ -26,7 +26,7 @@
                   class: "bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100" %>
 
       <%= link_to "Email Team Tickets",
-                  daily_report_path(team_name: params[:team_name]),
+                  daily_report_path(team_name: params[:team_name], report_type: params[:report_type]),
                   method: :get,
                   class: "bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded",
                   data: { confirm: "Are you sure you want to email the tickets to the team?" } %>


### PR DESCRIPTION
…efine daily report path and query optimizations

This pull request introduces changes to the `daily_report` functionality in the `DataCenterController` and updates the corresponding view to improve ticket filtering and email reporting. The most important changes include adding tag-based filtering for tickets, refining query logic, and updating the email report generation to ensure users only receive tickets relevant to them.

### Backend Logic Updates:
* Updated the `daily_report` method in `app/controllers/data_center_controller.rb` to include `:taggings` in the query joins, enabling tag-based filtering for tickets.
* Refined the logic for filtering tickets by status and report type, renaming variables for clarity and ensuring only relevant tickets are included in the query.
* Modified the email generation logic to send each user only the tickets they are tagged on, ensuring personalized and relevant reports.

### View Updates:
* Updated the "Email Team Tickets" button in `app/views/data_center/sod_report.html.erb` to include the `report_type` parameter, allowing for more granular control over the report type being sent.