### PR TITLE
Refine ticket query indentation, adjust HOD email logic, and improve …

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -446,8 +446,8 @@ class DataCenterController < ApplicationController
 
       user_ids = team.users.pluck(:id)
       base_scope = Ticket.joins(:users, project: :client)
-                         .joins(:statuses, :add_statuses, :taggings)
-                         .where(users: { id: user_ids })
+        .joins(:statuses, :add_statuses, :taggings)
+        .where(users: { id: user_ids })
 
       tickets = if current_user.has_role?(:admin) || current_user.has_role?(:observer)
                   base_scope
@@ -457,10 +457,10 @@ class DataCenterController < ApplicationController
 
       tickets = if report_type == 'closed'
                   tickets.where(statuses: { name: outstanding_statuses })
-                         .where('add_statuses.updated_at >= ?', 24.hours.ago)
+                    .where('add_statuses.updated_at >= ?', 24.hours.ago)
                 elsif report_type == 'eod'
                   recently_updated = tickets.where(statuses: { name: outstanding_statuses })
-                                            .where('add_statuses.updated_at >= ?', 24.hours.ago)
+                    .where('add_statuses.updated_at >= ?', 24.hours.ago)
                   tickets.where.not(statuses: { name: outstanding_statuses }).or(recently_updated)
                 else
                   tickets.where.not(statuses: { name: outstanding_statuses })
@@ -473,10 +473,10 @@ class DataCenterController < ApplicationController
       # Send to each user only the tickets they are tagged on
       team.users.each do |user|
         tagged_tickets = tickets
-                           .select('tickets.*, add_statuses.updated_at') # Include order column
-                           .joins(:taggings)
-                           .where(taggings: { user_id: user.id })
-                           .distinct
+          .select('tickets.*, add_statuses.updated_at') # Include order column
+          .joins(:taggings)
+          .where(taggings: { user_id: user.id })
+          .distinct
 
         next if tagged_tickets.empty?
 

--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -446,8 +446,8 @@ class DataCenterController < ApplicationController
 
       user_ids = team.users.pluck(:id)
       base_scope = Ticket.joins(:users, project: :client)
-        .joins(:statuses, :add_statuses, :taggings)
-        .where(users: { id: user_ids })
+                         .joins(:statuses, :add_statuses, :taggings)
+                         .where(users: { id: user_ids })
 
       tickets = if current_user.has_role?(:admin) || current_user.has_role?(:observer)
                   base_scope
@@ -457,25 +457,26 @@ class DataCenterController < ApplicationController
 
       tickets = if report_type == 'closed'
                   tickets.where(statuses: { name: outstanding_statuses })
-                    .where('add_statuses.updated_at >= ?', 24.hours.ago)
+                         .where('add_statuses.updated_at >= ?', 24.hours.ago)
                 elsif report_type == 'eod'
                   recently_updated = tickets.where(statuses: { name: outstanding_statuses })
-                    .where('add_statuses.updated_at >= ?', 24.hours.ago)
+                                            .where('add_statuses.updated_at >= ?', 24.hours.ago)
                   tickets.where.not(statuses: { name: outstanding_statuses }).or(recently_updated)
                 else
                   tickets.where.not(statuses: { name: outstanding_statuses })
                 end.order('add_statuses.updated_at DESC')
 
+      hod_emails = team.users.select { |u| u.has_role?(:hod) }.map(&:email)
       mail_options = {}
-      mail_options[:cc] = current_user.email if current_user.has_role?(:hod)
+      mail_options[:cc] = hod_emails if hod_emails.any?
 
       # Send to each user only the tickets they are tagged on
       team.users.each do |user|
         tagged_tickets = tickets
-          .select('tickets.*, add_statuses.updated_at') # Include order column
-          .joins(:taggings)
-          .where(taggings: { user_id: user.id })
-          .distinct
+                           .select('tickets.*, add_statuses.updated_at') # Include order column
+                           .joins(:taggings)
+                           .where(taggings: { user_id: user.id })
+                           .distinct
 
         next if tagged_tickets.empty?
 


### PR DESCRIPTION
…tagged ticket selection formatting in daily report logic

This pull request makes a small but impactful change to the `daily_report` method in the `DataCenterController`. It improves the handling of CC email recipients for users with the `:hod` role.

### Key Change:
* Replaced the logic for determining CC recipients by collecting all emails of users with the `:hod` role into a new `hod_emails` variable. This ensures that all `:hod` users are included in the CC list, rather than just the current user. (`app/controllers/data_center_controller.rb`, [app/controllers/data_center_controller.rbR469-R471](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bR469-R471))