### PR TITLE
Add DailyReportJob for automated daily ticket reporting and schedule …

### DIFF
--- a/.idea/CSPM.iml
+++ b/.idea/CSPM.iml
@@ -65,6 +65,7 @@
     <orderEntry type="library" scope="PROVIDED" name="chartkick (v5.1.2, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="childprocess (v5.1.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="choice (v0.2.0, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="chronic (v0.10.2, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="cloudinary (v2.2.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.3.4, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="connection_pool (v2.4.1, rbenv: 3.3.5) [gem]" level="application" />
@@ -189,6 +190,7 @@
     <orderEntry type="library" scope="PROVIDED" name="websocket (v1.2.11, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="websocket-driver (v0.7.6, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="websocket-extensions (v0.1.5, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="whenever (v1.0.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="xpath (v3.2.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="zeitwerk (v2.7.1, rbenv: 3.3.5) [gem]" level="application" />
   </component>

--- a/Gemfile
+++ b/Gemfile
@@ -102,3 +102,4 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'sidekiq'
 gem 'stackprof'
+gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
     childprocess (5.1.0)
       logger (~> 1.5)
     choice (0.2.0)
+    chronic (0.10.2)
     cloudinary (2.2.0)
       faraday (>= 2.0.1, < 3.0.0)
       faraday-follow_redirects (~> 0.3.0)
@@ -422,6 +423,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.1)
@@ -480,6 +483,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  whenever
 
 RUBY VERSION
    ruby 3.3.5p100

--- a/app/jobs/daily_report_job.rb
+++ b/app/jobs/daily_report_job.rb
@@ -1,0 +1,38 @@
+class DailyReportJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Team.find_each do |team|
+      send_report_to_team(team)
+    end
+  end
+
+  private
+
+  def send_report_to_team(team)
+    outstanding_statuses = %w[Closed Resolved Declined]
+
+    user_ids = team.users.pluck(:id)
+
+    base_scope = Ticket.joins(:users, project: :client)
+      .joins(:statuses, :add_statuses, :taggings)
+      .where(users: { id: user_ids })
+
+    tickets = base_scope.where.not(statuses: { name: outstanding_statuses })
+      .order('add_statuses.updated_at DESC')
+
+    hod_emails = team.users.select { |u| u.has_role?(:hod) }.map(&:email)
+    mail_options = {}
+    mail_options[:cc] = hod_emails if hod_emails.any?
+
+    team.users.each do |user|
+      tagged_tickets = tickets.select('tickets.*, add_statuses.updated_at')
+        .joins(:taggings)
+        .where(taggings: { user_id: user.id })
+        .order('add_statuses.updated_at DESC')
+        .distinct
+
+      UserMailer.daily_ticket_email(user, tagged_tickets.to_a, mail_options).deliver_later if tagged_tickets.any?
+    end
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,7 +23,7 @@
 set :output, "log/cron.log"
 set :environment, 'production'
 
-every 1.day, at: '1:00 pm' do
+every 1.day, at: '12:01 am' do
   runner "DailyReportJob.perform_later"
 end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,34 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+# Use this file to easily define all of your cron jobs.
+set :output, "log/cron.log"
+set :environment, 'production'
+
+every 1.day, at: '1:00 pm' do
+  runner "DailyReportJob.perform_later"
+end
+
+# For development (uncomment if you want to test locally)
+set :environment, 'development'
+every 1.day, at: '1: pm' do
+  runner "DailyReportJob.perform_later"
+end

--- a/spec/jobs/daily_report_job_spec.rb
+++ b/spec/jobs/daily_report_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DailyReportJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
…with Whenever gem

This pull request introduces a new scheduled job for generating daily reports and includes related configurations and dependencies. The most important changes involve adding the `whenever` gem for scheduling, implementing the `DailyReportJob` class, and configuring the cron schedule. Below is a summary of the changes grouped by theme:

### Job Implementation and Scheduling

* **New `DailyReportJob` class**: Added the `DailyReportJob` to generate daily reports for each team by fetching relevant tickets and sending emails to team members. The job includes logic to filter tickets and send emails with appropriate options. (`app/jobs/daily_report_job.rb`)

* **Cron schedule configuration**: Introduced a new `config/schedule.rb` file to define the cron job for running the `DailyReportJob` daily at 1:00 PM in both production and development environments. (`config/schedule.rb`)

### Dependency Updates

* **Added `whenever` gem**: Included the `whenever` gem in the `Gemfile` (with `require: false`) to enable cron job management. (`Gemfile`)

* **Updated `.idea/CSPM.iml`**: Registered the `whenever` gem in the project's `.idea` configuration file. (`.idea/CSPM.iml`)

### Testing

* **Placeholder test for `DailyReportJob`**: Added a pending RSpec test file for the `DailyReportJob` to set up future test cases. (`spec/jobs/daily_report_job_spec.rb`)