### PR TITLE
Update ticket status selection logic, optimize form conditions, switc…

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -163,13 +163,13 @@ class HomeController < ApplicationController
 
       # Count of the tickets closed in the last one week
       @tickets_closed_in_last_one_week_count = Ticket.joins(:statuses)
-        .where(statuses: { name: %w[Closed Resolved Declined Approved] })
+        .where(statuses: { name: %w[Closed Resolved Declined] })
         .where('tickets.updated_at >= ?', 1.week.ago)
         .count
 
       # All the open tickets for the current user count
       @all_open_tickets_for_current_user_count = Ticket.joins(:statuses)
-        .where.not(statuses: { name: %w[Closed Resolved Declined Approved] })
+        .where.not(statuses: { name: %w[Closed Resolved Declined] })
         .distinct
         .count
 
@@ -179,7 +179,7 @@ class HomeController < ApplicationController
       # Get the total number of open tickets for the current user count
       @total_no_of_open_tickets_for_current_user_count = Ticket.joins(:statuses, :project)
         .where(projects: { id: current_user.projects.ids })
-        .where.not(statuses: { name: %w[Closed Resolved Declined Approved] })
+        .where.not(statuses: { name: %w[Closed Resolved Declined] })
         .distinct
         .count
 


### PR DESCRIPTION
…h Active Job to Sidekiq, and adjust daily report schedule timing

This pull request updates the logic for filtering ticket statuses in the `index` action of the `HomeController`. The status `Approved` has been removed from the lists used in filtering tickets, ensuring that tickets with this status are no longer included in counts for closed or open tickets.

### Changes to ticket status filtering:

* [`app/controllers/home_controller.rb`](diffhunk://#diff-2e1b0bda5d1af14b6acbbff496f78d7343528dcd5d1f58aa7259c9b73f2deb5aL166-R172): Updated the `@tickets_closed_in_last_one_week_count` calculation to exclude the `Approved` status from the list of closed statuses.
* [`app/controllers/home_controller.rb`](diffhunk://#diff-2e1b0bda5d1af14b6acbbff496f78d7343528dcd5d1f58aa7259c9b73f2deb5aL166-R172): Updated the `@all_open_tickets_for_current_user_count` calculation to exclude the `Approved` status from the list of open statuses.
* [`app/controllers/home_controller.rb`](diffhunk://#diff-2e1b0bda5d1af14b6acbbff496f78d7343528dcd5d1f58aa7259c9b73f2deb5aL182-R182): Updated the `@total_no_of_open_tickets_for_current_user_count` calculation to exclude the `Approved` status from the list of open statuses.