### PR TITLE
Fix manage users show

### DIFF
--- a/app/views/project/_assign_people.html.erb
+++ b/app/views/project/_assign_people.html.erb
@@ -5,7 +5,7 @@
     <div>
       <h3 class="text-sm font-semibold mb-2">Craft Silicon Staff</h3>
       <p class="text-sm ">
-        <%= @craft_silicon_users.map(&:name).join(", ") %>
+        <%= @craft_silicon_users.map(&:name).join(", ").first(5) %>
       </p>
     </div>
 
@@ -13,7 +13,7 @@
     <div>
       <h3 class="text-sm font-semibold mb-2">Clients</h3>
       <p class="text-sm">
-        <%= @non_craft_silicon_users.map(&:name).join(", ") %>
+        <%= @non_craft_silicon_users.map(&:name).join(", ").first(5) %>
       </p>
     </div>
 

--- a/app/views/project/show.html.erb
+++ b/app/views/project/show.html.erb
@@ -100,12 +100,12 @@
                     <% software.groupwares.each do |groupware| %>
                       <% active_groupware = @project.tickets.where(groupware_id: groupware.id).count %>
                       <% if active_groupware > 0 %>
-                        <li class="grid grid-cols-2 gap-2 items-center">
+                        <li class="gap-2 items-center flex flex-wrap">
                           <span>
                             <% if groupware.image.present? %>
-                              <%= image_tag(groupware.image, class: 'sm:w-14 sm:h-14 md:w-16 md:h-16 rounded-md object-cover') %>
+                              <%= image_tag(groupware.image, class: 'sm:h-6 md:h-10 rounded-md object-cover') %>
                             <% else %>
-                              <%= image_tag 'default.png', class: 'sm:w-14 sm:h-14 md:w-16 md:h-16 rounded-md object-cover' %>
+                              <%= image_tag 'default.png', class: 'sm:h-6 sm:h-10 rounded-md object-cover' %>
                             <% end %>
                           </span>
                           

--- a/app/views/tickets/_ticket_topbar.html.erb
+++ b/app/views/tickets/_ticket_topbar.html.erb
@@ -24,11 +24,13 @@
       <span>New Ticket</span>
     <% end %>
     
+    <% if !current_user.has_role?(:client) %>
     <%= link_to manage_users_project_path(@project), data: { turbo_frame: "modal" }, class: "flex items-center gap-2 border-2 border-blue-500 bg-white hover:bg-blue-500 px-4 py-2 rounded-lg text-blue-500 hover:text-white font-medium transition-colors duration-200" do %>
       <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
         <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" />
       </svg>
       <span>Manage Users</span>
+    <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
This pull request introduces several updates to the user interface of the project management views, focusing on improving usability and refining the design. The key changes include limiting the display of user names in lists, adjusting the layout and styling of groupware elements, and adding a conditional check for displaying the "Manage Users" button.

### User Interface Improvements:

* **Limiting User Names in Lists**: Updated the `app/views/project/_assign_people.html.erb` file to limit the display of user names to the first five in both the "Craft Silicon Staff" and "Clients" sections. This prevents overly long lists from cluttering the interface.

* **Refined Groupware Layout and Styling**: Modified the `app/views/project/show.html.erb` file to change the layout of groupware elements from a grid to a flexible, wrap-friendly layout. Additionally, adjusted the image dimensions for groupware icons to be smaller and more consistent.

* **Conditional Display of "Manage Users" Button**: Added a conditional check in `app/views/tickets/_ticket_topbar.html.erb` to ensure the "Manage Users" button is only displayed to users who do not have the `:client` role, improving role-based access control.