### PR TITLE
Update ticket status transition map to include empty status for 'New'…

### DIFF
--- a/app/views/tickets/_ticket_action.html.erb
+++ b/app/views/tickets/_ticket_action.html.erb
@@ -46,7 +46,7 @@
     <%= form_with url: add_status_project_ticket_path(@project, @ticket), local: true do %>
       <% current_status = @ticket.statuses.first&.name %>
       <% transition_map = {
-        'New' => ['Assigned'],
+        'New' => ['Assigned', ""],
         'Assigned' => ['Work in Progress'],
         'Work in Progress' => ['Declined', 'Resolved', 'On-Hold', 'Under Development', 'Client Confirmation Pending'],
         'On-Hold' => ['Under Development', 'Work in Progress'],


### PR DESCRIPTION
… tickets

This pull request includes a small update to the status transition logic in the `app/views/tickets/_ticket_action.html.erb` file. The change adds an empty string (`""`) as a possible transition for tickets with the status "New".