### PR TITLE
Refine ticket action condition to handle 'Change' issue type alongsid…

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -424,10 +424,24 @@ class TicketsController < ApplicationController
   # Update the issue type of a ticket
   def update_issue_type
     @ticket = Ticket.find(params[:id])
-    @ticket.skip_sla_callbacks = true
+
+    @ticket.skip_sla_callbacks = params[:ticket][:issue] != 'NEW FEATURE'
 
     if @ticket.update(issue: params[:ticket][:issue])
       respond_to do |format|
+        if @ticket.issue == 'NEW FEATURE'
+          sla = SlaTicket.find_or_initialize_by(ticket_id: @ticket.id)
+          sla.update!(
+            sla_status: 'NO SLA',
+            sla_target_response_deadline: 'NO SLA',
+            sla_resolution_deadline: 'NO SLA'
+          )
+        else
+          SlaTicket.find_or_create_by!(ticket_id: @ticket.id) do |sla_ticket|
+            sla_ticket.sla_status = @ticket.sla_status
+          end
+        end
+
         format.js
         format.html { redirect_to project_ticket_path(@ticket.project, @ticket), notice: 'Issue type updated successfully.' }
       end


### PR DESCRIPTION
…e 'CHANGE REQUEST'.
This pull request modifies the `update_issue_type` method in `tickets_controller.rb` to handle SLA (Service Level Agreement) updates based on the ticket's issue type. The changes ensure proper SLA handling for tickets marked as "NEW FEATURE."

### SLA handling improvements:

* Updated the `@ticket.skip_sla_callbacks` logic to skip SLA callbacks only when the issue type is "NEW FEATURE."
* Added conditional logic to create or update `SlaTicket` records:
  - For "NEW FEATURE" tickets, `SlaTicket` is updated with "NO SLA" values for SLA status and deadlines.
  - For other tickets, `SlaTicket` is created or updated with the ticket's SLA status.