### PR TITLE
Set target repair and resolution deadlines after ticket priority update.

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -342,6 +342,9 @@ class TicketsController < ApplicationController
     @ticket = Ticket.find(params[:id])
 
     if @ticket.update(priority: params[:ticket][:priority])
+      @ticket.set_target_repair_deadline
+      @ticket.set_resolution_deadline
+
       respond_to do |format|
         format.js
         format.html { redirect_to project_ticket_path(@ticket.project, @ticket), notice: 'Priority updated successfully.' }


### PR DESCRIPTION
This pull request introduces an enhancement to the `update_priority` method in the `TicketsController`. The most important change is the addition of logic to automatically set deadlines when a ticket's priority is updated.

Enhancements to ticket priority updates:

* [`app/controllers/tickets_controller.rb`](diffhunk://#diff-d4c5ab3656241a42b628137d4f0e84e6fbaa7bb928bc4569b9cfe442a583ffcdR345-R347): Added calls to `set_target_repair_deadline` and `set_resolution_deadline` in the `update_priority` method to ensure deadlines are automatically set when the ticket's priority is updated.