### PR TITLE
Fix conditional rendering of users in issue edit form to handle both …

### DIFF
--- a/app/views/issues/_edit_form.html.erb
+++ b/app/views/issues/_edit_form.html.erb
@@ -34,11 +34,19 @@
                  autocomplete="off">
           
           <div id="selectedUsers-<%= issue.id %>" class="flex flex-wrap gap-2 mt-2">
-            <% issue.users.each do |user| %>
+            <% if issue.respond_to?(:users) %>
+              <% issue.users.each do |user| %>
+                <div class="bg-blue-100 text-blue-800 px-2 py-1 rounded-md flex items-center gap-2 text-sm">
+                  <%= user.name %>
+                  <span onclick="removeUser('<%= issue.id %>', '<%= user.id %>', this)" class="cursor-pointer text-red-500">×</span>
+                  <input type="hidden" name="team[user_ids][]" value="<%= user.id %>" class="user-input-<%= user.id %>">
+                </div>
+              <% end %>
+            <% elsif issue.respond_to?(:user) && issue.user.present? %>
               <div class="bg-blue-100 text-blue-800 px-2 py-1 rounded-md flex items-center gap-2 text-sm">
                 <%= issue.user.name %>
-                <span onclick="removeUser('<%= issue.id %>', '<%= user.id %>', this)" class="cursor-pointer text-red-500">×</span>
-                <input type="hidden" name="team[user_ids][]" value="<%= user.id %>" class="user-input-<%= user.id %>">
+                <span onclick="removeUser('<%= issue.id %>', '<%= issue.user.id %>', this)" class="cursor-pointer text-red-500">×</span>
+                <input type="hidden" name="team[user_ids][]" value="<%= issue.user.id %>" class="user-input-<%= issue.user.id %>">
               </div>
             <% end %>
           </div>


### PR DESCRIPTION
…`users` collection and single `user` object.
This pull request updates the `app/views/issues/_edit_form.html.erb` file to enhance user handling in the issue edit form. The changes ensure compatibility with both single-user and multi-user scenarios, improving flexibility and robustness.

Enhancements to user handling:

* Added conditional logic to check if `issue` responds to `:users` or `:user`, allowing the form to handle multiple users (`issue.users`) or a single user (`issue.user`) appropriately.
* Updated the loop to iterate over `issue.users` instead of `issue.user`, ensuring proper handling of multiple user objects.
* Included fallback logic to display a single user if `issue.user` is present but `issue.users` is not, maintaining backward compatibility.