### PR TITLE
Refactor project table: restrict edit option to admins, add row click…

### DIFF
--- a/app/views/project/_project_table.html.erb
+++ b/app/views/project/_project_table.html.erb
@@ -9,8 +9,7 @@
       <th scope="col" class="px-4 px-2">Assignee</th>
       <th scope="col" class="px-4 px-2">Client</th>
       <th scope="col" class="px-4 px-2">Product Category</th>
-      <th scope="col" class="px-4 px-2">VIEW</th>
-      <% if current_user.has_role? :admin or current_user.has_role?('project manager') %>
+      <% if current_user.has_role? :admin %>
         <% if can? :edit, @project %>
           <th scope="col" class="px-4 px-2">EDIT</th>
         <% end %>
@@ -23,8 +22,8 @@
     <tbody>
     <% @project.each do |project| %>  <!-- Looping through each project -->
       <% if project.assigned_to?(current_user) || current_user.has_role?(:admin) or current_user.has_role?(:observer) or current_user.has_role?(:agent)  %>
-        <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 h-12 text-center">
-          <td class="px-4 py-4 font-medium text-left">
+        <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 h-12 text-center" style="cursor:pointer;" onclick="window.location='<%= project_path(project.id) %>'">          <td class="px-4 py-4 font-medium text-left">
+
             <% if project.image.present? %>
               <%= link_to project_path(project.id) do %>
                 <%= image_tag(project.image, class: 'w-16') %>
@@ -59,10 +58,7 @@
                 <%= software.name %>
               <% end %>
           </td>
-          <td class="px-4 py-4 text-left">
-            <%= link_to "VIEW", project_path(project.id), class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100', id: 'button' %>
-          </td>
-          <% if current_user.has_role? :admin or current_user.has_role?('project manager') %>
+          <% if current_user.has_role? :admin %>
             <% if can? :edit, project %>
               <td class="px-4 py-4 text-left">
                 <%= link_to 'Edit', edit_project_path(project), class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100', id: 'button' %>


### PR DESCRIPTION
… navigation, and remove redundant "VIEW" button.
This pull request makes several changes to the `app/views/project/_project_table.html.erb` file to refine user role-based access and improve user experience with clickable rows. The most notable updates include removing access for project managers to edit projects, making table rows clickable for easier navigation, and removing the "VIEW" button to streamline the interface.

### Role-based access adjustments:
* Restricted editing functionality to users with the `admin` role only, removing access previously granted to users with the `project manager` role. [[1]](diffhunk://#diff-a28008a863a12520a57aad9e8eab7a3d1dc3da4b613e186621075da2b9289667L12-R12) [[2]](diffhunk://#diff-a28008a863a12520a57aad9e8eab7a3d1dc3da4b613e186621075da2b9289667L62-R61)

### User experience improvements:
* Made table rows clickable by adding an `onclick` event that redirects users to the project's detail page, enhancing navigation.
* Removed the "VIEW" button from the table to simplify the interface and rely on the new clickable row functionality for navigation. [[1]](diffhunk://#diff-a28008a863a12520a57aad9e8eab7a3d1dc3da4b613e186621075da2b9289667L12-R12) [[2]](diffhunk://#diff-a28008a863a12520a57aad9e8eab7a3d1dc3da4b613e186621075da2b9289667L62-R61)