### PR TITLE
Enhance action dropdown: prevent right-click context menu on quick vi…

### DIFF
--- a/app/views/issues/_issue_topbar.html.erb
+++ b/app/views/issues/_issue_topbar.html.erb
@@ -1,7 +1,7 @@
 <div class="grid grid-cols-2 ">
   <div class="col-span-1 flex">
     <div class="flex flex-wrap gap-1">
-      <button onclick="history.back()" class="bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100">
+      <button onclick="history.back()" class="bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 h-12 items-center rounded font-bold rounded-md text-slate-100">
         &#8656; Back
       </button>
     </div>

--- a/app/views/tickets/_action_dropdown.html.erb
+++ b/app/views/tickets/_action_dropdown.html.erb
@@ -45,13 +45,17 @@
           <path stroke-linecap="round" stroke-linejoin="round"
                 d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
         </svg>
+
+
         <%= link_to 'QUICK VIEW',
                     modal_show_project_ticket_path(ticket.project, ticket),
-                    data: { 
+                    data: {
                       turbo_frame: "modal",
-                      action: "click->dropdown#hide" 
+                      action: "click->dropdown#hide contextmenu->dropdown#prevent"
                     },
-                    class: 'text-sm hover:text-blue-600 hover:underline' %>
+                    class: 'text-sm hover:text-blue-600 hover:underline',
+                    oncontextmenu: "return false;" %>
+
       </div>
 
       <% if can?(:edit, ticket) %>

--- a/app/views/tickets/_ticketshow_top_left.html.erb
+++ b/app/views/tickets/_ticketshow_top_left.html.erb
@@ -29,7 +29,7 @@
           <span class="text-gray-800 dark:text-gray-200 group-hover:text-blue-700 dark:group-hover:text-blue-400">
             <%= render partial: 'ticket_status', locals: { ticket: @ticket } %>
           </span>
-          <% unless (@ticket.statuses.first&.name == 'Closed' or @ticket.statuses.first&.name == 'Resolved') && !current_user.has_role?(:admin) %>
+          <% unless (@ticket.statuses.first&.name == 'Closed') && !current_user.has_role?(:admin) %>
 
           <button type="button"
                   class="flex items-center gap-2 px-3 py-1.5 rounded-lg transition-all hover:bg-blue-50 dark:hover:bg-blue-900/30 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-offset-2 dark:focus:ring-offset-gray-800"

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -77,7 +77,7 @@
         </span>
       </div>
       <div class="mb-2.5 font-bold capitalize flex">
-        <% unless (@ticket.statuses.first&.name == 'Closed' or @ticket.statuses.first&.name == 'Resolved') && !current_user.has_role?(:admin) %>
+        <% unless (@ticket.statuses.first&.name == 'Closed') && !current_user.has_role?(:admin) %>
           <%= render 'tickets/ticket_action' %>
         <% end %>
       </div>


### PR DESCRIPTION
…ew link
This pull request includes updates to the `app/views/tickets/_action_dropdown.html.erb` file to enhance user interaction for the "QUICK VIEW" link. 

Enhancements to user interaction:

* Updated the `data-action` attribute of the "QUICK VIEW" link to include a `contextmenu->dropdown#prevent` action, preventing the default context menu from appearing when right-clicking the link.
* Added the `oncontextmenu` attribute to the "QUICK VIEW" link with `return false;`, ensuring the right-click context menu is disabled.