### PR TITLE
Update project report view: add new ticket statuses (QA Testing, On H…

### DIFF
--- a/app/views/data_center/project_report.html.erb
+++ b/app/views/data_center/project_report.html.erb
@@ -78,9 +78,13 @@
         <th class="border border-gray-300 px-4 py-2">Total Open Tickets</th>
         <th class="border border-gray-300 px-4 py-2">Assigned</th>
         <th class="border border-gray-300 px-4 py-2">Work in Progress</th>
+        <th class="border border-gray-300 px-4 py-2">QA Testing</th>
+        <th class="border border-gray-300 px-4 py-2">On Hold</th>
         <th class="border border-gray-300 px-4 py-2">Under Development</th>
         <th class="border border-gray-300 px-4 py-2">Client Confirmation Pending</th>
         <th class="border border-gray-300 px-4 py-2">Awaiting Build</th>
+        <th class="border border-gray-300 px-4 py-2">Reopened</th>
+
         <th class="border border-gray-300 px-4 py-2">Initial Response Breaches</th>
         <th class="border border-gray-300 px-4 py-2">Target Response Breaches</th>
         <th class="border border-gray-300 px-4 py-2">Target Resolution Breaches</th>
@@ -91,9 +95,12 @@
       <% # Totals row %>
       <% total_assigned = @team_members.sum { |user| (@organized_tickets[user.id] || {})['Assigned'].to_i } %>
       <% total_wip = @team_members.sum { |user| (@organized_tickets[user.id] || {})['Work in Progress'].to_i } %>
+      <% total_qa = @team_members.sum { |user| (@organized_tickets[user.id] || {})['QA Testing'].to_i } %>
+      <% total_oh = @team_members.sum { |user| (@organized_tickets[user.id] || {})['On-Hold'].to_i } %>
       <% total_ud = @team_members.sum { |user| (@organized_tickets[user.id] || {})['Under Development'].to_i } %>
       <% total_ccp = @team_members.sum { |user| (@organized_tickets[user.id] || {})['Client Confirmation Pending'].to_i } %>
       <% total_ab = @team_members.sum { |user| (@organized_tickets[user.id] || {})['Awaiting Build'].to_i } %>
+      <% total_re = @team_members.sum { |user| (@organized_tickets[user.id] || {})['Reopened'].to_i } %>
       <% total_total = @team_members.sum { |user| (@organized_tickets[user.id] || {})[:total].to_i } %>
       <% total_open = @team_members.sum { |user| (@tickets_chart_data[user.name] || 0).to_i } %>
       <% total_sla_status = @team_members.sum { |user| (@sla_status[user.id] || 0).to_i } %>
@@ -106,9 +113,12 @@
         <td class="border border-gray-300 px-4 py-2"><%= total_open %></td>
         <td class="border border-gray-300 px-4 py-2"><%= total_assigned %></td>
         <td class="border border-gray-300 px-4 py-2"><%= total_wip %></td>
+        <td class="border border-gray-300 px-4 py-2"><%= total_qa %></td>
+        <td class="border border-gray-300 px-4 py-2"><%= total_oh %></td>
         <td class="border border-gray-300 px-4 py-2"><%= total_ud %></td>
         <td class="border border-gray-300 px-4 py-2"><%= total_ccp %></td>
         <td class="border border-gray-300 px-4 py-2"><%= total_ab %></td>
+        <td class="border border-gray-300 px-4 py-2"><%= total_re %></td>
         <td class="border border-gray-300 px-4 py-2"><%= total_sla_status %></td>
         <td class="border border-gray-300 px-4 py-2"><%= total_sla_trd %></td>
         <td class="border border-gray-300 px-4 py-2"><%= total_sla_rd %></td>
@@ -124,9 +134,12 @@
           <td class="border border-gray-300 px-4 py-2"><%= @tickets_chart_data[user.name] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Assigned'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Work in Progress'] || 0 %></td>
+          <td class="border border-gray-300 px-4 py-2"><%= ticket_data['QA Testing'] || 0 %></td>
+          <td class="border border-gray-300 px-4 py-2"><%= ticket_data['On-Hold'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Under Development'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Client Confirmation Pending'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Awaiting Build'] || 0 %></td>
+          <td class="border border-gray-300 px-4 py-2"><%= ticket_data['Reopened'] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= @sla_status[user.id] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= @sla_target_response_deadline[user.id] || 0 %></td>
           <td class="border border-gray-300 px-4 py-2"><%= @sla_resolution_deadline[user.id] || 0 %></td>


### PR DESCRIPTION
…old, Reopened) and calculate their totals.
This pull request enhances the `project_report.html.erb` view by adding new ticket categories to the report table, ensuring that these categories are included in totals, and displaying their respective values for individual team members. The changes improve the comprehensiveness of the report by capturing additional ticket statuses.

### Additions to ticket categories in the report:

* Added new columns for "QA Testing," "On Hold," and "Reopened" in the table header to represent additional ticket statuses. (`app/views/data_center/project_report.html.erb`)

### Updates to totals calculation:

* Updated the totals row to calculate the sum of tickets for the newly added categories: "QA Testing," "On Hold," and "Reopened." (`app/views/data_center/project_report.html.erb`)

### Display of new ticket categories:

* Added cells to display the totals for "QA Testing," "On Hold," and "Reopened" in the report's total row. (`app/views/data_center/project_report.html.erb`)
* Updated the per-user ticket data row to include values for "QA Testing," "On Hold," and "Reopened." (`app/views/data_center/project_report.html.erb`)