### PR TITLE
Update ticket views: remove reporter and subject columns for simplifi…

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -38,7 +38,7 @@
           Active Project Manager<br>(Project Managers who have logged in more than once)
         </p>
         <span class="text-lg sm:text-xl font-bold">
-          <%= @project_managers_who_have_loggedin_more_than_once_count %>`
+          <%= @project_managers_who_have_loggedin_more_than_once_count %>
         </span>
       </div>
       <% end %>

--- a/app/views/tickets/_all_open_tickets_body.html.erb
+++ b/app/views/tickets/_all_open_tickets_body.html.erb
@@ -43,13 +43,6 @@
         </div>
       </td>
 
-      <!-- Reported by -->
-      <td class="px-2 py-2 capitalize">
-        <div class="relative w-full flex justify-center">
-          <%= ticket.user.name if ticket.user.name.present? %>
-        </div>
-      </td>
-
       <!-- View button -->
       <td class="px-4 py-4 whitespace-nowrap font-medium" data-controller="dropdown" data-dropdown-ticket-id-value="<%= ticket.id %>">
         <%= render partial: 'tickets/action_dropdown', locals: { ticket: ticket } %>

--- a/app/views/tickets/all_open_tickets.html.erb
+++ b/app/views/tickets/all_open_tickets.html.erb
@@ -11,9 +11,6 @@
     <th class="py-2 px-4 border-b">ASSIGNEE</th>
     <th class="py-2 px-4 border-b">STATUS</th>
     <th class="py-2 px-4 border-b">PROGRESS</th>
-
-    <th class="py-2 px-4 border-b">REPORTER</th>
-
     <th class="py-2 px-4 border-b">VIEW</th>
   </tr>
   </thead>

--- a/app/views/tickets/all_tickets.html.erb
+++ b/app/views/tickets/all_tickets.html.erb
@@ -4,16 +4,11 @@
     <th class="py-2 px-4 border-b">ID</th>
     <th class="py-2 px-4 border-b">Date</th>
     <th class="py-2 px-4 border-b">SERVICE DESK NAME</th>
-
     <th class="py-2 px-4 border-b">ISSUE</th>
-
     <th class="py-2 px-4 border-b">PRIORITY</th>
-    <th class="py-2 px-4 border-b">SUBJECT</th>
-
     <th class="py-2 px-4 border-b">ASSIGNEE</th>
     <th class="py-2 px-4 border-b">STATUS</th>
     <th class="py-2 px-4 border-b">PROGRESS</th>
-
     <th class="py-2 px-4 border-b">VIEW</th>
   </tr>
   </thead>
@@ -32,16 +27,10 @@
       <th scope="row" class="px-2 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white">
         <%= link_to ticket.issue, project_ticket_path(ticket.project, ticket) %>
       </th>
-
       <!-- Priority -->
       <td class="px-2 py-2">
         <div class="relative w-full flex justify-center">
           <%= render partial: "tickets/priority_severity", locals: { ticket: ticket } %>
-        </div>
-      </td>
-      <td class="px-2 py-2 truncate w-64">
-        <div class="relative w-full flex justify-start text-left">
-          <%= ticket.subject.truncate(50) if ticket.subject.present? %>
         </div>
       </td>
       <td class="px-2 py-2 font-bold">
@@ -51,21 +40,18 @@
           <% end %>
         </div>
       </td>
-
       <!-- Ticket Status -->
       <td class="px-2 py-2">
         <div class="relative w-full flex justify-center">
           <%= render partial: "tickets/ticket_status", locals: { ticket: ticket } %>
         </div>
       </td>
-
       <!-- Progress Bar -->
       <td class="pl-2 pr-2 py-2">
         <div class="relative w-full flex justify-center">
             <%= render partial: "tickets/progress_bar", locals: { ticket: ticket } %>
         </div>
       </td>
-
       <td class="px-4 py-4 whitespace-nowrap font-medium" data-controller="dropdown" data-dropdown-ticket-id-value="<%= ticket.id %>">
         <%= render partial: 'tickets/action_dropdown', locals: { ticket: ticket } %>
       </td>

--- a/app/views/tickets/closed_tickets_one_week.erb
+++ b/app/views/tickets/closed_tickets_one_week.erb
@@ -4,12 +4,9 @@
     <th class="py-2 px-4 border-b">ID</th>
     <th class="py-2 px-4 border-b">Date</th>
     <th class="py-2 px-4 border-b">SERVICE DESK NAME</th>
-
     <th class="py-2 px-4 border-b">ISSUE</th>
-
     <th class="py-2 px-4 border-b">PRIORITY</th>
     <th class="py-2 px-4 border-b">SUBJECT</th>
-
     <th class="py-2 px-4 border-b">ASSIGNEE</th>
     <th class="py-2 px-4 border-b">STATUS</th>
     <th class="py-2 px-4 border-b">PROGRESS</th>

--- a/app/views/tickets/created_tickets_one_week.html.erb
+++ b/app/views/tickets/created_tickets_one_week.html.erb
@@ -4,12 +4,9 @@
     <th class="py-2 px-4 border-b">ID</th>
     <th class="py-2 px-4 border-b">Date</th>
     <th class="py-2 px-4 border-b">SERVICE DESK NAME</th>
-
     <th class="py-2 px-4 border-b">ISSUE</th>
-
     <th class="py-2 px-4 border-b">PRIORITY</th>
     <th class="py-2 px-4 border-b">SUBJECT</th>
-
     <th class="py-2 px-4 border-b">ASSIGNEE</th>
     <th class="py-2 px-4 border-b">STATUS</th>
     <th class="py-2 px-4 border-b">PROGRESS</th>
@@ -31,22 +28,18 @@
       <th scope="row" class="px-2 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white">
         <%= link_to ticket.issue, project_ticket_path(ticket.project, ticket) %>
       </th>
-      
       <!-- Priority and severity -->
       <td class="px-2 py-2">
         <div class="relative w-full flex justify-center">
           <%= render partial: "tickets/priority_severity", locals: { ticket: ticket } %>
         </div>
       </td>
-
       <!-- Ticket subject -->
       <td class="px-2 py-2 truncate w-64">
         <div class="relative w-full flex justify-start text-left">
           <%= ticket.subject.truncate(50) if ticket.subject.present? %>
         </div>
       </td>
-
-
       <td class="px-2 py-2 font-bold">
         <div class="relative w-full flex justify-center">
           <% ticket.users.each do |user| %>
@@ -54,26 +47,22 @@
           <% end %>
         </div>
       </td>
-
       <!-- Ticket Status -->
       <td class="px-2 py-2">
         <div class="relative w-full flex justify-center">
           <%= render partial: "tickets/ticket_status", locals: { ticket: ticket } %>
         </div>
       </td>
-
       <!-- Progress Bar -->
       <td class="pl-2 pr-5 py-2">
         <div class="relative w-full flex justify-center">
             <%= render partial: "tickets/progress_bar", locals: { ticket: ticket } %>
         </div>
       </td>
-
       <!-- View button -->
       <td class="px-4 py-4 whitespace-nowrap font-medium" data-controller="dropdown" data-dropdown-ticket-id-value="<%= ticket.id %>">
         <%= render partial: 'tickets/action_dropdown', locals: { ticket: ticket } %>
       </td>
-
     </tr>
   <% end %>
   </tbody>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -6,7 +6,6 @@
     <th class="py-2 px-4 border-b">SERVICE DESK NAME</th>
     <th class="py-2 px-4 border-b">ISSUE</th>
     <th class="py-2 px-4 border-b">PRIORITY</th>
-    <th class="py-2 px-4 border-b">SUBJECT</th>
     <th class="py-2 px-4 border-b">ASSIGNEE</th>
     <th class="py-2 px-4 border-b">STATUS</th>
     <th class="py-2 px-4 border-b">PROGRESS</th>
@@ -33,13 +32,6 @@
       <td class="px-2 py-2">
         <div class="relative w-full flex justify-center">
           <%= render partial: "tickets/priority_severity", locals: { ticket: ticket } %>
-        </div>
-      </td>
-
-      <!-- Ticket subject -->
-      <td class="px-2 py-2 truncate w-64">
-        <div class="relative w-full flex justify-start text-left">
-          <%= ticket.subject.truncate(50) if ticket.subject.present? %>
         </div>
       </td>
 

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -27,7 +27,6 @@
       <th scope="row" class="px-2 py-2 font-medium text-gray-900 whitespace-nowrap dark:text-white">
         <%= link_to ticket.issue, project_ticket_path(ticket.project, ticket) %>
       </th>
-      
       <!-- Priority and severity -->
       <td class="px-2 py-2">
         <div class="relative w-full flex justify-center">


### PR DESCRIPTION
…ed layout.
This pull request removes certain columns from the tickets table views for a cleaner and more focused UI. Specifically, the "Reporter" and "Subject" columns have been removed across relevant views.

### Removal of "Reporter" column:

* [`app/views/tickets/_all_open_tickets_body.html.erb`](diffhunk://#diff-3598a53eaddbd985760519f3f64c6762917832a7d50b9bd4b54f172e10890ab5L46-L52): Removed the "Reported by" column, which displayed the name of the user who reported the ticket.
* [`app/views/tickets/all_open_tickets.html.erb`](diffhunk://#diff-01344f9071152e7cbe0f4c8394590a81799757f97f45b067f0fea46c08b8bbb7L14-L16): Removed the "REPORTER" header from the table.

### Removal of "Subject" column:

* [`app/views/tickets/index.html.erb`](diffhunk://#diff-37939c3dcd02077128ca9d17fb15cad29dc04c6107a9ae54ca55c2e6edf7a018L9): Removed the "SUBJECT" header and its corresponding data column, which displayed the ticket's subject truncated to 50 characters. [[1]](diffhunk://#diff-37939c3dcd02077128ca9d17fb15cad29dc04c6107a9ae54ca55c2e6edf7a018L9) [[2]](diffhunk://#diff-37939c3dcd02077128ca9d17fb15cad29dc04c6107a9ae54ca55c2e6edf7a018L39-L45)