### PR TITLE
Update ticket views: restrict status options to 'Closed' and 'Reopene…

### DIFF
--- a/app/views/tickets/_ticket_action.html.erb
+++ b/app/views/tickets/_ticket_action.html.erb
@@ -74,7 +74,7 @@
       <% current_status = @ticket.statuses.first&.name %>
       <% allowed = ["Client Confirmation Pending", "Resolved", "Reopened",  "Closed",  "Declined"] %>
       <% if allowed.include?(current_status) %>
-        <%= select_tag :status_id, options_for_select(Status.where(name: %w[Closed Reopened Resolved]).pluck(:name, :id), @ticket.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
+        <%= select_tag :status_id, options_for_select(Status.where(name: %w[Closed Reopened]).pluck(:name, :id), @ticket.statuses.first.id), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
         <%= submit_tag "UPDATE STATUS", class: 'w-full font-semibold bg-blue-500 hover:bg-blue-600 text-white p-3 rounded-lg mt-2' %>
       <% end %>
     <% end %>


### PR DESCRIPTION
…d' only.
This pull request includes a minor update to the ticket status dropdown in the `app/views/tickets/_ticket_action.html.erb` file. The change removes the "Resolved" status from the list of selectable options in the dropdown.

* **Dropdown options update**: The `select_tag` now only includes "Closed" and "Reopened" statuses, removing "Resolved" as a selectable option.