### PR TITLE
Align the Actions dropdown button properly

### DIFF
--- a/app/views/client/_client.html.erb
+++ b/app/views/client/_client.html.erb
@@ -73,8 +73,8 @@
 
         <!-- Actions li -->
         <% if can?(:edit, client) || can?(:delete, client) %>
-          <td class="px-6 py-4 whitespace-nowrap font-medium text-right w-1/4" data-controller="dropdown" data-dropdown-ticket-id-value="<%= client.id %>">
-            <div class="relative flex justify-end"> 
+          <td class="px-6 py-4 whitespace-nowrap font-medium text-right" data-controller="dropdown" data-dropdown-ticket-id-value="<%= client.id %>">
+            <div class="relative flex justify-start"> 
               <%= render partial: 'client/action_dropdown', locals: { client: client } %>
             </div>
           </td>

--- a/app/views/defect/_defect.html.erb
+++ b/app/views/defect/_defect.html.erb
@@ -65,8 +65,8 @@
               <%= defect.product.client&.name || "N/A" %>
             </td>
             <!-- Actions 11 -->
-            <td class="px-4 py-4" data-controller="dropdown" data-dropdown-ticket-id-value="<%= defect.id %>">
-              <div class="relative w-full flex justify-center">
+            <td class="px-6 py-4 text-right" data-controller="dropdown" data-dropdown-ticket-id-value="<%= defect.id %>">
+              <div class="relative w-full flex justify-start">
                 <%= render partial: 'defect/action_dropdown', locals: { defect: defect } %>
               </div>
             </td>

--- a/app/views/product/_product_list.html.erb
+++ b/app/views/product/_product_list.html.erb
@@ -69,8 +69,8 @@
           </td>
 
           <!-- Actions 11 -->
-          <td class="px-4 py-4 whitespace-nowrap font-medium" data-controller="dropdown" data-dropdown-ticket-id-value="<%= product.id %>">
-            <div class="relative w-full flex justify-center">
+          <td class="px-6 py-4 whitespace-nowrap font-medium text-right" data-controller="dropdown" data-dropdown-ticket-id-value="<%= product.id %>">
+            <div class="relative w-full flex justify-start">
               <%= render partial: 'product/action_dropdown', locals: { product: product } %>
             </div>
           </td>

--- a/app/views/project/_project_table.html.erb
+++ b/app/views/project/_project_table.html.erb
@@ -56,7 +56,7 @@
             <% if can?(:edit, project) || can?(:delete, project) %>
               <!-- Actions li -->
               <td class="px-6 py-4 whitespace-nowrap font-medium text-right" data-controller="dropdown" data-dropdown-ticket-id-value="<%= project.id %>" onclick="event.stopPropagation()"> 
-                <div class="relative flex justify-end"> 
+                <div class="relative flex justify-start"> 
                   <%= render partial: 'project/action_dropdown', locals: { project: project } %>
                 </div>
               </td>

--- a/app/views/software/_software.html.erb
+++ b/app/views/software/_software.html.erb
@@ -9,7 +9,7 @@
           Description of the software
         </th>
         <% if can?(:edit, @software) || can?(:delete, @software) %>
-          <th scope="col" class="px-6 py-3 w-1/4 text-right">
+          <th scope="col" class="px-6 py-3">
             ACTIONS
           </th>
         <% end %>
@@ -29,8 +29,8 @@
 
           <% if can?(:edit, software) || can?(:delete, software) %>
             <!-- Actions li -->
-            <td class="px-6 py-4 whitespace-nowrap font-medium text-right w-1/4" data-controller="dropdown" data-dropdown-ticket-id-value="<%= software.id %>"> 
-              <div class="relative flex justify-end"> 
+            <td class="px-6 py-4 whitespace-nowrap font-medium text-right" data-controller="dropdown" data-dropdown-ticket-id-value="<%= software.id %>"> 
+              <div class="relative flex justify-start"> 
                 <%= render partial: 'software/action_dropdown', locals: { software: software } %>
               </div>
             </td>

--- a/app/views/team/_team.html.erb
+++ b/app/views/team/_team.html.erb
@@ -23,7 +23,7 @@
           </td>
           <!-- Actions li -->
           <td class="px-6 py-4 whitespace-nowrap font-medium text-right" data-controller="dropdown" data-dropdown-ticket-id-value="<%= team.id %>"> 
-            <div class="relative flex justify-end"> 
+            <div class="relative flex justify-start"> 
               <%= render partial: 'team/action_dropdown', locals: { team: team } %>
             </div>
           </td>


### PR DESCRIPTION
Align the Actions dropdown button to start instead of end for the project, product, clients, teams, software resources/ tables. The actions dropdown was originally showing as misplaced and was not showing where it is supposed to be creating a disparity in the shown UI for the user.

This was working on the Issue #970 