### PR TITLE
Update project report generation: filter out closed, resolved, and de…

### DIFF
--- a/app/controllers/data_center_controller.rb
+++ b/app/controllers/data_center_controller.rb
@@ -215,7 +215,7 @@ class DataCenterController < ApplicationController
         .count
 
       @sla_resolution_deadline = Ticket.joins(:statuses, :project, :taggings, :sla_tickets)
-        .where(sla_tickets: { sla_target_response_deadline: ['Breached'] })
+        .where(sla_tickets: { sla_resolution_deadline: ['Breached'] })
         .where('tickets.created_at >= ? AND tickets.created_at <= ?', start_date.beginning_of_day, end_date.end_of_day)
         .group('taggings.user_id')
         .count


### PR DESCRIPTION
…clined tickets from CSV export

This pull request includes a small but important change in the `project_report` method of the `DataCenterController`. It updates the query to use `sla_resolution_deadline` instead of `sla_target_response_deadline` when filtering breached SLA tickets.

* [`app/controllers/data_center_controller.rb`](diffhunk://#diff-5382ba0f357664c4c7a6f965190a1011cbf297a35eec86b33a4f9e41adb9147bL218-R218): Updated the `where` clause in the `@sla_resolution_deadline` query to reference `sla_resolution_deadline` instead of `sla_target_response_deadline`, ensuring the correct SLA field is used for filtering breached deadlines.