### PR TITLE
Remove unused partials for creating and removing users from product s…

### DIFF
--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -10,10 +10,6 @@
     <p class="capitalize text-sm text-balance">
       <%= @product.description.truncate(100) %>
     </p>
-    <div>
-      <%= render 'product/add_users' %>
-      <%= render 'product/remove_user' %>
-    </div>
     <% unless current_user.has_role?(:client) %>
     <div class="mt-2">
       <% new_board = Board.find_by(status: 'TO DO') %>


### PR DESCRIPTION
…how view.
This pull request removes unused partials related to user management from the product show page. The changes clean up the view by eliminating unnecessary code.

* [`app/views/product/show.html.erb`](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fL13-L16): Removed the rendering of the `add_users` and `remove_user` partials, as they are no longer in use.