### PR TITLE
Fix dropdown background in project user assignment: add light mode su…

### DIFF
--- a/app/views/project/_add_assign.html.erb
+++ b/app/views/project/_add_assign.html.erb
@@ -29,7 +29,7 @@
         <div class="relative space-y-2">
           <input type="text" id="searchCraftUser" class="w-full border border-gray-300 dark:bg-gray-500 rounded px-3 py-2 text-sm shadow-sm focus:ring focus:border-blue-500 placeholder-gray-400 dark:placeholder-gray-300" placeholder="Search User..." onkeyup="filterCraftDropdown()">
 
-          <div id="craftDropdown" class="hidden absolute w-full dark:bg-gray-500 border rounded mt-1 shadow-md max-h-40 overflow-y-auto z-10">
+          <div id="craftDropdown" class="hidden absolute w-full bg-white dark:bg-gray-500 border rounded mt-1 shadow-md max-h-40 overflow-y-auto z-10">
             <% @project.craftsilicon_users.where.not(id: @project.users.pluck(:id)).distinct.each do |user| %>
               <div class="dropdown-item px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer" data-user-id="<%= user.id %>" onclick="selectCraftUser(this)">
                 <%= user.name %>


### PR DESCRIPTION
…pport.
This pull request includes a minor change to the `app/views/project/_add_assign.html.erb` file. The change ensures that the dropdown background color is explicitly set to white in light mode for better visual consistency.

* **UI Improvement**:
  - Updated the `craftDropdown` div to include `bg-white` in light mode, ensuring the dropdown background is explicitly white instead of relying on default styles. (`[app/views/project/_add_assign.html.erbL32-R32](diffhunk://#diff-7beb150af06b45c1a128a31d8147fcaacaad9c668acf798ce7ac046a4edc887cL32-R32)`)