### PR TITLE
Add pagination count variables to product controller.

### DIFF
--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -16,6 +16,10 @@ class ProductController < ApplicationController
     @per_page = 12
     @page = (params[:page] || 1).to_i
     @total_pages = (@product.count / @per_page.to_f).ceil
+    # show the count for the page
+    @start_count = (@page - 1) * @per_page + 1
+    @end_count = [@page * @per_page, @product.count].min
+    @total_count = @product.count
     @product = @product.offset((@page - 1) * @per_page).limit(@per_page)
   end
 

--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -17,7 +17,7 @@ class ProductController < ApplicationController
     @page = (params[:page] || 1).to_i
     @total_pages = (@product.count / @per_page.to_f).ceil
     # show the count for the page
-    @start_count = (@page - 1) * @per_page + 1
+    @start_count = ((@page - 1) * @per_page) + 1
     @end_count = [@page * @per_page, @product.count].min
     @total_count = @product.count
     @product = @product.offset((@page - 1) * @per_page).limit(@per_page)


### PR DESCRIPTION
This pull request includes a small enhancement to the `index` method in the `app/controllers/product_controller.rb` file. The change introduces variables to display the count of products for the current page.

* [`app/controllers/product_controller.rb`](diffhunk://#diff-fb6d52c8e1f572d48fbc714f60fe113386ded18750f81b19ca971fbb4a4d9996R19-R22): Added `@start_count`, `@end_count`, and `@total_count` variables to calculate and show the product count for the current page.