### PR TITLE
Tasks all fixed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
   before_action :load_notifications, if: :user_signed_in?
 
   # Handle missing records by redirecting to root with an alert
-  rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_root
+  # rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_root
 
   # Handle authorization errors by redirecting to root with an alert
   rescue_from CanCan::AccessDenied do |exception|
@@ -66,7 +66,7 @@ class ApplicationController < ActionController::Base
   end
 
   # Redirects to root with a not found alert
-  def redirect_to_root
-    redirect_to root_path, alert: 'The page you were looking for does not exist.'
-  end
+  # def redirect_to_root
+  #  redirect_to root_path, alert: 'The page you were looking for does not exist.'
+  # end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
   before_action :load_notifications, if: :user_signed_in?
 
   # Handle missing records by redirecting to root with an alert
-  # rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_root
+  rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_root
 
   # Handle authorization errors by redirecting to root with an alert
   rescue_from CanCan::AccessDenied do |exception|
@@ -66,7 +66,7 @@ class ApplicationController < ActionController::Base
   end
 
   # Redirects to root with a not found alert
-  # def redirect_to_root
-  #  redirect_to root_path, alert: 'The page you were looking for does not exist.'
-  # end
+  def redirect_to_root
+    redirect_to root_path, alert: 'The page you were looking for does not exist.'
+  end
 end

--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -75,7 +75,7 @@ class ProductController < ApplicationController
       #   .count
 
       # @product_tasks_per_board_status = board_statuses.index_with { |status| task_counts[status] || 0 }
-      @tasks_by_status = @product.tasks.includes(:statuses).group_by { |task| task.statuses.first&.name || "Uncategorized" }
+      @tasks_by_status = @product.tasks.includes(:statuses).group_by { |task| task.statuses.first&.name || 'Uncategorized' }
     else
       redirect_to root_path, alert: 'You are not authorized to view this content.'
     end

--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -28,13 +28,6 @@ class ProductController < ApplicationController
 
       @days_remaining = (@product.end_date - Date.today).to_i if @product.end_date.present?
 
-      # Show the count of the tasks per status in the product boards
-      @product.boards.pluck(:status).uniq
-      # task_counts = Task.joins(:board)
-      #  .where(boards: { product_id: @product.id })
-      #  .group('boards.status')
-      #  .count
-
       # Define status groups
       @open_statuses = ['TO DO', 'In Progress', 'On-Hold', 'Failed-QA', 'QA-testing',
                         'Await Client Information', 'Reopened',
@@ -61,20 +54,6 @@ class ProductController < ApplicationController
         @tasks = @product.tasks
       end
 
-      # Group filtered tasks by board (always run this)
-      # @filtered_tasks_by_board = @tasks.group_by(&:board_id)
-
-      # Get counts for each status group
-      # @open_tasks_count = @product.tasks.joins(:board).where(boards: { status: @open_statuses }).count
-      # @closed_tasks_count = @product.tasks.joins(:board).where(boards: { status: @closed_statuses }).count
-      # @awaiting_client_tasks_count = @product.tasks.joins(:board).where(boards: { status: @awaiting_client_statuses }).count
-      # @my_open_tasks = @product.tasks
-      # .joins(:board, :users)
-      #  .where(boards: { status: @open_statuses })
-      #  .where(users: { id: current_user.id })
-      #   .count
-
-      # @product_tasks_per_board_status = board_statuses.index_with { |status| task_counts[status] || 0 }
       @tasks_by_status = @product.tasks.includes(:statuses).group_by { |task| task.statuses.first&.name || 'Uncategorized' }
     else
       redirect_to root_path, alert: 'You are not authorized to view this content.'

--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -25,14 +25,10 @@ class ProductController < ApplicationController
 
   def show
     if current_user.has_role?(:admin) || @product.users.include?(current_user)
-      preferred_order = ['TO DO', 'In Progress', 'On-Hold', 'Failed-QA', 'QA-testing', 'Blocked',
-                         'Await Client Information', 'Reopened', 'Awaiting Build', 'Support Testing',
-                         'Awaiting Client API', 'Resolved', 'Closed']
-      @boards = preferred_order.flat_map do |status|
-        boards = @product.boards.includes(:tasks).where(status: status)
-        boards = boards.joins(:tasks).where('tasks.name ILIKE ?', "%#{params[:query]}%") if params[:query].present?
-        boards
-      end
+      # @boards = preferred_order.flat_map do |status|
+      boards = @product.boards.includes(:tasks).where(status: status)
+      boards.joins(:tasks).where('tasks.name ILIKE ?', "%#{params[:query]}%") if params[:query].present?
+      # end
 
       # Only override if no search query is present:
       @boards = @product.boards unless params[:query].present?
@@ -41,11 +37,11 @@ class ProductController < ApplicationController
       @days_remaining = (@product.end_date - Date.today).to_i if @product.end_date.present?
 
       # Show the count of the tasks per status in the product boards
-      board_statuses = @product.boards.pluck(:status).uniq
-      task_counts = Task.joins(:board)
-        .where(boards: { product_id: @product.id })
-        .group('boards.status')
-        .count
+      @product.boards.pluck(:status).uniq
+      # task_counts = Task.joins(:board)
+      #  .where(boards: { product_id: @product.id })
+      #  .group('boards.status')
+      #  .count
 
       # Define status groups
       @open_statuses = ['TO DO', 'In Progress', 'On-Hold', 'Failed-QA', 'QA-testing',
@@ -74,19 +70,19 @@ class ProductController < ApplicationController
       end
 
       # Group filtered tasks by board (always run this)
-      @filtered_tasks_by_board = @tasks.group_by(&:board_id)
+      # @filtered_tasks_by_board = @tasks.group_by(&:board_id)
 
       # Get counts for each status group
-      @open_tasks_count = @product.tasks.joins(:board).where(boards: { status: @open_statuses }).count
-      @closed_tasks_count = @product.tasks.joins(:board).where(boards: { status: @closed_statuses }).count
-      @awaiting_client_tasks_count = @product.tasks.joins(:board).where(boards: { status: @awaiting_client_statuses }).count
-      @my_open_tasks = @product.tasks
-        .joins(:board, :users)
-        .where(boards: { status: @open_statuses })
-        .where(users: { id: current_user.id })
-        .count
+      # @open_tasks_count = @product.tasks.joins(:board).where(boards: { status: @open_statuses }).count
+      # @closed_tasks_count = @product.tasks.joins(:board).where(boards: { status: @closed_statuses }).count
+      # @awaiting_client_tasks_count = @product.tasks.joins(:board).where(boards: { status: @awaiting_client_statuses }).count
+      # @my_open_tasks = @product.tasks
+      # .joins(:board, :users)
+      #  .where(boards: { status: @open_statuses })
+      #  .where(users: { id: current_user.id })
+      #   .count
 
-      @product_tasks_per_board_status = board_statuses.index_with { |status| task_counts[status] || 0 }
+      # @product_tasks_per_board_status = board_statuses.index_with { |status| task_counts[status] || 0 }
 
     else
       redirect_to root_path, alert: 'You are not authorized to view this content.'

--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -25,15 +25,7 @@ class ProductController < ApplicationController
 
   def show
     if current_user.has_role?(:admin) || @product.users.include?(current_user)
-      # @boards = preferred_order.flat_map do |status|
-      boards = @product.boards.includes(:tasks).where(status: status)
-      boards.joins(:tasks).where('tasks.name ILIKE ?', "%#{params[:query]}%") if params[:query].present?
-      # end
 
-      # Only override if no search query is present:
-      @boards = @product.boards unless params[:query].present?
-
-      @todo_board = @boards.find { |board| board.status == 'TO DO' } || @boards.first
       @days_remaining = (@product.end_date - Date.today).to_i if @product.end_date.present?
 
       # Show the count of the tasks per status in the product boards
@@ -83,7 +75,7 @@ class ProductController < ApplicationController
       #   .count
 
       # @product_tasks_per_board_status = board_statuses.index_with { |status| task_counts[status] || 0 }
-
+      @tasks_by_status = @product.tasks.includes(:statuses).group_by { |task| task.statuses.first&.name || "Uncategorized" }
     else
       redirect_to root_path, alert: 'You are not authorized to view this content.'
     end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy add_task remove_task add_state]
 
   def index
-    @tasks = @board.tasks
+    @tasks = @product.tasks
   end
 
   def new
@@ -79,15 +79,17 @@ class TasksController < ApplicationController
   end
 
   def add_state
-    @task = @board.tasks.find(params[:id])
+    status = Status.find(params[:status_id])
 
-    if @task.board_id == params[:status].to_i
-      redirect_to product_path(@product), alert: 'The task is already in the selected state.'
+    if status.nil?
+      respond_to do |format|
+        format.html { redirect_to product_task_path(@product, @task), alert: 'Invalid status ID' }
+      end
       return
     end
 
-    @task.board_id = params[:status]
-    @task.save
+    @task.statuses.clear
+    @task.statuses << status
 
     UserMailer.add_state_email(@task.user, @task, current_user).deliver_later
     # @product.users.each do |product_user|

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,6 @@
 class TasksController < ApplicationController
   before_action :authenticate_user!
   before_action :set_product
-  before_action :set_board
   before_action :set_task, only: %i[show edit update destroy add_task remove_task add_state]
 
   def index
@@ -9,12 +8,11 @@ class TasksController < ApplicationController
   end
 
   def new
-    @task = @board.tasks.new
+    @task = @product.tasks.new
   end
 
   def create
-    @task = @board.tasks.new(task_params)
-    @task.product_id = params[:product_id]
+    @task = @product.tasks.new(task_params)
     @task.user = current_user
 
     respond_to do |format|
@@ -22,15 +20,17 @@ class TasksController < ApplicationController
         current_user.add_role :creator, @task
         format.html { redirect_to product_path(@product), notice: 'Task was successfully created.' }
       else
+        Sentry.capture_message("Task creation failed: #{@task.errors.full_messages.join(', ')}")
+        Rails.logger.error("Task creation failed: #{@task.errors.full_messages.join(', ')}")
         format.html do
-          redirect_to new_product_board_task_path(@product, @board, @task), notice: 'Task was not created.'
+          redirect_to new_product_task_path(@product), notice: 'Task was not created.'
         end
       end
     end
   end
 
   def show
-    @task = @board.tasks.find(params[:id])
+    @task = @product.tasks.find(params[:id])
   end
 
   def edit; end
@@ -52,9 +52,9 @@ class TasksController < ApplicationController
 
   def add_task
     if @task.users.include?(User.find(params[:user_id]))
-      redirect_to product_board_task_path(@product, @board, @task), notice: 'User has already been assigned.'
+      redirect_to product_tasks_path(@product, @task), notice: 'User has already been assigned.'
     else
-      @task = @board.tasks.find(params[:id])
+      @task = @product.tasks.find(params[:id])
       @task.user = current_user
       user = User.find(params[:user_id])
       @task.users.clear
@@ -69,13 +69,13 @@ class TasksController < ApplicationController
       #   UserMailer.task_assignment_email(product_user, @task, current_user, assigned_user).deliver_later
       # end
 
-      redirect_to product_board_task_path(@product, @board, @task), notice: 'Task was successfully assigned.'
+      redirect_to product_tasks_path(@product, @task), notice: 'Task was successfully assigned.'
     end
   end
 
   def remove_task
     @task.users.delete(User.find(params[:user_id]))
-    redirect_to product_board_task_path(@product, @board, @task), notice: 'Task was successfully unassigned.'
+    redirect_to product_task_path(@product, @task), notice: 'Task was successfully unassigned.'
   end
 
   def add_state
@@ -104,16 +104,11 @@ class TasksController < ApplicationController
     @product = Product.find(params[:product_id])
   end
 
-  def set_board
-    @board = @product.boards.find(params[:board_id])
-  end
-
   def set_task
-    @task = @board.tasks.find(params[:id])
+    @task = @product.tasks.find(params[:id])
   end
 
   def task_params
-    params.require(:task).permit(:name, :topic, :description, :start_date, :end_date, :image, :file, :board_id,
-                                 :user_id)
+    params.require(:task).permit(:name, :topic, :description, :start_date, :end_date, :image, :file, :user_id)
   end
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1,7 +1,6 @@
 class Board < ApplicationRecord
   belongs_to :product
   belongs_to :user
-  has_many :tasks, dependent: :nullify
 
   resourcify
   # To ensure that the ticket are connected to the user and their roles well defined

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -4,4 +4,5 @@ class Status < ApplicationRecord
   has_many :status_bugs
   has_many :bugs, through: :status_bugs, dependent: :destroy
   has_and_belongs_to_many :products, dependent: :destroy
+  has_and_belongs_to_many :tasks, dependent: :destroy
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,6 +16,7 @@ class Task < ApplicationRecord
 
   has_many :add_tasks
   has_many :users, through: :add_tasks, dependent: :destroy
+  has_and_belongs_to_many :statuses, dependent: :destroy
   has_many :bugs
   has_rich_text :description
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :user
   belongs_to :product
-  belongs_to :board
   has_one_attached :image
   has_one_attached :file
   has_many :messages, dependent: :destroy

--- a/app/views/boards/_board_display.html.erb
+++ b/app/views/boards/_board_display.html.erb
@@ -13,19 +13,12 @@
 
         <% unless current_user.has_role?(:client) %>
         <div class="flex flex-wrap">
-          <%= link_to new_product_board_task_path(@product.id, board.id) do %>
+          <%= link_to new_product_task_path(@product.id) do %>
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
               <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 7.5h-.75A2.25 2.25 0 0 0 4.5 9.75v7.5a2.25 2.25 0 0 0 2.25 2.25h7.5a2.25 2.25 0 0 0 2.25-2.25v-7.5a2.25 2.25 0 0 0-2.25-2.25h-.75m-6 3.75 3 3m0 0 3-3m-3 3V1.5m6 9h.75a2.25 2.25 0 0 1 2.25 2.25v7.5a2.25 2.25 0 0 1-2.25 2.25h-7.5a2.25 2.25 0 0 1-2.25-2.25v-.75" />
             </svg>
           <% end %>
 
-          <% if can? :read, board %>
-            <%= button_to [board.product, board], method: :delete, data: { 'turbo-method': :delete, 'turbo-confirm': 'Are you sure?' } do %>
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-              </svg>
-            <% end %>
-          <% end %>
         </div>
         <% end %>
       </div>

--- a/app/views/product/_product_show_topbar.html.erb
+++ b/app/views/product/_product_show_topbar.html.erb
@@ -18,18 +18,7 @@
   <!-- Tickets topbar right side -->
   <div class="flex justify-end items-center gap-3">
     <!-- If there is no board created that is todo, this will not show. Show create first board -->
-    <% todo_board = @boards.find { |board| board.status == 'TO DO' } %>
-    <% if todo_board %>
-      <%= link_to 'Add Task', new_product_board_task_path(@product.id, todo_board.id), class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100' %>
-    <% elsif @boards.any? %>
-      <%= link_to 'Create TO DO Board', new_product_board_path(@product.id, status: 'TO DO'), class: 'bg-yellow-500 hover:bg-yellow-600 p-2 rounded font-bold rounded-lg text-slate-100' %>
-    <% else %>
-      <%= link_to 'Create First Board', new_product_board_path(@product.id), class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100' %>
-    <% end %>
-
-    <% if current_user.has_role? :admin %>
-      <%= button_to 'Add New Status +', new_product_board_path(@product.id), method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100'  %>
-    <% end %>
+      <%= link_to 'Add Task', new_product_task_path(@product), class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100' %>
     
     <% if current_user.has_role?(:admin) || current_user.has_role?('project manager') %>
       <%= link_to manage_users_product_path(@product), data: { turbo_frame: "modal" }, class: "flex items-center gap-2 border-2 border-blue-500 bg-white hover:bg-blue-500 px-4 py-2 rounded-lg text-blue-500 hover:text-white font-medium transition-colors duration-200" do %>

--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -73,10 +73,10 @@
   <% if @product.added_to?(current_user) || current_user.has_role?(:admin) %>
     <div class="w-full overflow-x-auto transform origin-top scale-90 md:scale-100">
       <% @product.tasks.each do |task| %>
-        <div class="w-full min-w-0">
-          <%= render partial: 'tasks/card', locals: { task: task } %>
-        </div>
+          <div class="w-full min-w-0">
+            <%= render partial: 'tasks/card', locals: { task: task } %>
+          </div>
       <% end %>
+    </div>
   <% end %>
 </div>
-

--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -22,7 +22,7 @@
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z" />
           </svg>
-          <h2 class="text-md font-light">Board Status Counts</h2>
+          <h2 class="text-md font-light">Status Counts</h2>
         </div>
       </div>
     </div>

--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -71,12 +71,36 @@
 
 <div class="relative max-w-full">
   <% if @product.added_to?(current_user) || current_user.has_role?(:admin) %>
-    <div class="w-full overflow-x-auto transform origin-top scale-90 md:scale-100">
-      <% @product.tasks.each do |task| %>
-          <div class="w-full min-w-0">
-            <%= render partial: 'tasks/card', locals: { task: task } %>
+    <div class="h-screen p-2 overflow-x-auto">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-5 min-w-full">
+
+        <% @tasks_by_status.each do |status, tasks| %>
+          <div class="bg-white rounded px-2 py-2 min-w-[280px]">
+            <!-- Board Header -->
+            <div class="flex justify-between items-center mb-2 mx-1">
+              <div class="flex items-center">
+                <h2 class="bg-gray-200 text-sm w-max px-2 py-1 rounded text-gray-700 capitalize"><%= status %></h2>
+                <p class="text-gray-400 text-sm ml-2"><%= tasks.count %></p>
+              </div>
+              <div class="text-gray-300 text-2xl">+</div>
+            </div>
+
+            <!-- Board Cards -->
+            <div class="grid gap-2">
+              <% tasks.each do |task| %>
+                <%= render partial: 'tasks/card', locals: { task: task } %>
+              <% end %>
+            </div>
+
+            <!-- Add new -->
+            <div class="flex flex-row items-center text-gray-300 mt-2 px-1 cursor-pointer">
+              <p class="text-2xl mr-2">+</p>
+              <p class="pt-1 text-sm">New</p>
+            </div>
           </div>
-      <% end %>
+        <% end %>
+
+      </div>
     </div>
-  <% end %>
+<% end %>
 </div>

--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -75,7 +75,7 @@
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-5 min-w-full">
 
         <% @tasks_by_status.each do |status, tasks| %>
-          <div class="bg-white rounded px-2 py-2 min-w-[280px]">
+          <div class="bg-white dark:bg-gray-700 rounded px-2 py-2 min-w-[280px]">
             <!-- Board Header -->
             <div class="flex justify-between items-center mb-2 mx-1">
               <div class="flex items-center">
@@ -90,12 +90,6 @@
               <% tasks.each do |task| %>
                 <%= render partial: 'tasks/card', locals: { task: task } %>
               <% end %>
-            </div>
-
-            <!-- Add new -->
-            <div class="flex flex-row items-center text-gray-300 mt-2 px-1 cursor-pointer">
-              <p class="text-2xl mr-2">+</p>
-              <p class="pt-1 text-sm">New</p>
             </div>
           </div>
         <% end %>

--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -24,32 +24,39 @@
           </svg>
           <h2 class="text-md font-light">Board Status Counts</h2>
         </div>
-        
-        <% if @product_tasks_per_board_status.any? %>
-          <ul class="space-y-3">
-            <% @product_tasks_per_board_status.each do |topic, count| %>
-              <li class="grid grid-cols-[1fr_auto] items-center">
-                <span class="font-medium text-gray-800 dark:text-gray-200"><%= topic %></span>
-                <span class="bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-3 py-1 rounded-full text-sm font-semibold">
-                  <%= count %> task(s)
-                </span>
-              </li>
-            <% end %>
-          </ul>
-        <% else %>
-          <p class="text-gray-600 dark:text-gray-300 text-sm">
-            No boards created. <%= link_to 'Create one here', new_product_board_path(@product.id), 
-            class: 'text-blue-600 dark:text-blue-400 underline hover:text-blue-800 dark:hover:text-blue-300' %>.
-          </p>
-        <% end %>
       </div>
     </div>
 
     <!-- Fourth Column -->
     <div class="px-16 grid grid-cols-[auto_1fr_auto] gap-3 sm:gap-4 col-span-1">
-      <div class="flex w-full">
-        <% if current_user.has_role? :admin %>
-          <%= render partial: 'product/add_statuses' %>
+      <div class="flex flex-col">
+        <h2 class="text-md font-light">Products</h2>
+        <div class="text-md font-semibold">
+          <% if @product.softwares.any? %>
+            <ul class="flex flex-wrap gap-4 items-center">
+
+            </ul>
+          <% else %>
+            <p>No sub-product present</p>
+          <% end %>
+        </div>
+      </div>
+
+      <!-- show added documents name and download button -->
+      <div class="flex">
+        <% if @product.documents.any? %>
+          <ul>
+            <% @product.documents.each do |document| %>
+              <li class="flex gap-2">
+                <h1 class="capitalize"><%= document.name %></h1>
+                <% if document.file.attached? %>
+                  - <%= link_to "Download", rails_blob_path(document.file, disposition: "attachment"), class: "text-blue-500" %>
+                <% else %>
+                  <span class="text-gray-400">No file</span>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
         <% end %>
       </div>
     </div>
@@ -65,8 +72,11 @@
 <div class="relative max-w-full">
   <% if @product.added_to?(current_user) || current_user.has_role?(:admin) %>
     <div class="w-full overflow-x-auto transform origin-top scale-90 md:scale-100">
-      <%= render 'boards/board_display' %>
-    </div>
+      <% @product.tasks.each do |task| %>
+        <div class="w-full min-w-0">
+          <%= render partial: 'tasks/card', locals: { task: task } %>
+        </div>
+      <% end %>
   <% end %>
 </div>
 

--- a/app/views/tasks/_add_state.html.erb
+++ b/app/views/tasks/_add_state.html.erb
@@ -2,7 +2,7 @@
   <% if current_user.has_role? :admin or current_user.has_role?('project manager') or current_user.has_role? :agent %>
     <div class="grid grid-cols-2 mt-2 gap-2">
       <div class="col-span-1 text-xs">
-        <%= form_with url: add_state_product_board_task_path(@product, @board, @task), local: true do %>
+        <%= form_with url: add_state_product_task_path(@product, @task), local: true do %>
           <%= label_tag :status, "SELECT STATE" %>
           <div class="flex">
             <div>

--- a/app/views/tasks/_add_state.html.erb
+++ b/app/views/tasks/_add_state.html.erb
@@ -6,7 +6,7 @@
           <%= label_tag :status, "SELECT STATE" %>
           <div class="flex">
             <div>
-              <%= select_tag :status, options_for_select(@product.boards.map { |board| [board.status, board.id] }), class: "mr-1 form-select block rounded-md border-gray-300 text-black shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm", required: true %>
+              <%= select_tag :status_id, options_for_select(Status.where(name: ['TO DO', 'Closed', 'Await Client Information']).pluck(:name, :id)), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
             </div>
             <div class=" col-span-1">
               <%= submit_tag "STATUS CHANGE", class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' %>

--- a/app/views/tasks/_add_task.html.erb
+++ b/app/views/tasks/_add_task.html.erb
@@ -2,7 +2,7 @@
 <% if current_user.has_role? :admin or current_user.has_role?('project manager') or current_user.has_role? :agent %>
   <div class="grid grid-cols-2 mt-2 gap-2">
     <div class="col-span-1 text-xs">
-      <%= form_with url: add_task_product_board_task_path(@product, @board, @task), local: true do %>
+      <%= form_with url: add_task_product_task_path(@product, @task), local: true do %>
         <%= label_tag :user_id, "SELECT USER" %>
         <div class="flex gap-2 mt-2">
           <div>

--- a/app/views/tasks/_card.html.erb
+++ b/app/views/tasks/_card.html.erb
@@ -28,9 +28,9 @@
           <%= task.name %>
         </h3>
         <p class="my-4">
-        <% if task.description.nil? %>
-        <%= sanitize raw (task.description.to_trix_html) %>
-<% end %>
+          <% if task.description.nil? %>
+            <%= sanitize raw (task.description.to_trix_html) %>
+          <% end %>
         </p>
         <div class="text-xs text-gray-500 dark:text-gray-400">
           <%= task.topic %>
@@ -56,6 +56,9 @@
               <%= truncate(user.email, length: 15, omission: '...') %>
             <% end %>
           <% end %>
+        </div>
+        <div class="text-xs text-gray-500 dark:text-gray-400 mt-2">
+          <span class="font-semibold">Status:</span> <%= task.statuses.first&.name %>
         </div>
       </figcaption>
     </figure>

--- a/app/views/tasks/_card.html.erb
+++ b/app/views/tasks/_card.html.erb
@@ -1,7 +1,7 @@
 <%= link_to product_task_path(task.product, task) do %>
-  <div class="m-2 border border-gray-200 rounded shadow-sm dark:border-gray-700 bg-white w-full max-w-md">
-    <figure class="flex flex-col items-center justify-center p-2 text-center bg-white border-b border-gray-200 rounded-t-lg md:rounded-t-none md:rounded-ss-lg md:border-e dark:bg-gray-800 dark:border-gray-700">
-      <blockquote class="w-full max-w-xs sm:max-w-sm md:max-w-md mx-auto mb-4 text-gray-500 lg:mb-8 dark:text-gray-400">
+  <div class="m-2 border border-gray-200 rounded shadow-sm dark:border-gray-700 w-full">
+    <figure class="flex flex-col items-center justify-center p-2 text-center bg-white border-b border-gray-200 rounded-md md:border-e dark:bg-gray-800 dark:border-gray-700">
+      <blockquote class="w-full max-w-xs sm:max-w-sm md:max-w-md mx-auto mb-4 text-gray-500 dark:text-gray-400">
       <% due_date = task.end_date %>
       <% days_left = (due_date - Date.today).to_i %>
       <% due_date_class = case

--- a/app/views/tasks/_card.html.erb
+++ b/app/views/tasks/_card.html.erb
@@ -1,4 +1,4 @@
-<%= link_to product_board_task_path(task.product, task.board, task) do %>
+<%= link_to product_task_path(task.product, task) do %>
   <div class="m-2 border border-gray-200 rounded shadow-sm dark:border-gray-700 bg-white w-full max-w-md">
     <figure class="flex flex-col items-center justify-center p-2 text-center bg-white border-b border-gray-200 rounded-t-lg md:rounded-t-none md:rounded-ss-lg md:border-e dark:bg-gray-800 dark:border-gray-700">
       <blockquote class="w-full max-w-xs sm:max-w-sm md:max-w-md mx-auto mb-4 text-gray-500 lg:mb-8 dark:text-gray-400">

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,5 +1,5 @@
 
-  <%= form_with(model: [product, board, board.tasks.build]) do |f| %>
+  <%= form_with(model: [product, product.tasks.build ]) do |f| %>
 
     <div class="gap-2 m-2">
       <%= link_to product_path(@product.id), method: :get, class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' do %>
@@ -27,9 +27,7 @@
         <%= f.file_field :file, accept: '*/*', class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
       </div>
 
-      <% new_board = Board.find_by(status: 'TO DO') %>
-      <%= f.hidden_field :board_id, value: new_board.id %>
-    </div>
+
     <% if flash[:alert] %>
       <div class="alert alert-danger">
         <%= flash[:alert] %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,5 +1,5 @@
 
-  <%= form_with(model: [@product, @board, @task], method: :patch) do |f| %>
+  <%= form_with(model: [@product, @task], method: :patch) do |f| %>
     <div class="gap-2 m-2">
       <%= link_to product_path(@product.id), method: :get, class: 'mb-4 h-12 bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100' do %>
         &#8656; Back
@@ -24,10 +24,6 @@
         <div class="relative z-0 w-full mb-6 group">
           <%= f.label :file, ('Task File'), class: "capitalize block mb-1 text-sm font-medium" %><br />
           <%= f.file_field :file, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: '' %>
-        </div>
-        <div class="relative z-0 w-full mb-6 group">
-          <%= f.label :status, 'Board Status', class: "capitalize block mb-1 text-sm font-medium" %><br />
-          <%= f.collection_select :board_id, @product.boards, :id, :status, {prompt: "Select Status"}, {class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", disabled: true} %>
         </div>
       </div>
       <% if flash[:alert] %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,3 +1,3 @@
-<%= render 'tasks/form', product: @product, board: @board %>
+<%= render 'tasks/form', product: @product %>
 
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -78,6 +78,14 @@
         </div>
       </div>
     </div>
+    <div>
+      <div class="flex items-center">
+        <h5 class="block mt-2 text-2xl font-semibold mr-2">Task End Date:</h5>
+        <span class="mt-2  text-xl capitalize">
+          <%= @task.end_date.strftime("%d %b %Y") %>
+        </span>
+      </div>
+    </div>
 
     <div>
       <div class="flex items-center">

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -89,9 +89,9 @@
 
     <div>
       <div class="flex items-center">
-        <h5 class="block mt-2 text-2xl font-semibold mr-2">Task End Date:</h5>
+        <h5 class="block mt-2 text-2xl font-semibold mr-2">Status:</h5>
         <span class="mt-2  text-xl capitalize">
-          <%= @task.end_date.strftime("%d %b %Y") %>
+          <%= @task.statuses.first&.name %>
         </span>
       </div>
     </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -11,10 +11,10 @@
         <!-- Delete Button -->
 
         <% if current_user.has_role? :admin or current_user.has_role?('project manager') %>
-          <%= button_to edit_product_board_task_path(@product, @board, @task), method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100' do %>
+          <%= button_to edit_product_task_path(@product, @task), method: :get, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100' do %>
             Edit
           <% end %>
-          <%= button_to product_board_task_path(@product, @board), method: :delete, data: { confirm: 'Are you sure?' }, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100' do %>
+          <%= button_to product_task_path(@product), method: :delete, data: { confirm: 'Are you sure?' }, class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100' do %>
           Delete Task
         <% end %>
           </div>
@@ -28,7 +28,7 @@
       <%= link_to "Download #{@task.file.filename}", url_for(@task.file), target: "_blank", class: "text-blue-600 hover:underline" %>
 
     <% else %>
-      This task does not have an uploaded file. If you need to add a file, kindly <%= link_to "edit", edit_product_board_task_path(@product, @board, @task), method: :get, class: 'underline text-[#3F8CFF]' %> the task to include it.
+      This task does not have an uploaded file. If you need to add a file, kindly <%= link_to "edit", edit_product_task_path(@product, @task), method: :get, class: 'underline text-[#3F8CFF]' %> the task to include it.
     <% end %>
     <div class="flex flex-row">
       <%= render 'tasks/add_task' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,14 +81,12 @@ Rails.application.routes.draw do
       delete :remove_user
       post :product_status
     end
-    resources :boards do
-      resources :tasks do
-        member do
-          post :add_task
-          delete :remove_task
-          post :add_state
-          delete :remove_state
-        end
+    resources :tasks do
+      member do
+        post :add_task
+        delete :remove_task
+        post :add_state
+        delete :remove_state
       end
     end
   end

--- a/db/migrate/20250714123446_remove_board_id_from_tasks.rb
+++ b/db/migrate/20250714123446_remove_board_id_from_tasks.rb
@@ -1,0 +1,5 @@
+class RemoveBoardIdFromTasks < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :tasks, :board_id, :uuid
+  end
+end

--- a/db/migrate/20250714144657_create_join_table_tasks_status.rb
+++ b/db/migrate/20250714144657_create_join_table_tasks_status.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableTasksStatus < ActiveRecord::Migration[7.2]
+  def change
+    create_join_table :tasks, :statuses, column_options: { type: :uuid } do |t|
+      t.index [:task_id, :status_id]
+      t.index [:status_id, :task_id]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_14_123446) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_14_144657) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -413,6 +413,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_14_123446) do
     t.datetime "updated_at", null: false
     t.uuid "user_id", null: false
     t.index ["user_id"], name: "index_statuses_on_user_id"
+  end
+
+  create_table "statuses_tasks", id: false, force: :cascade do |t|
+    t.uuid "task_id", null: false
+    t.uuid "status_id", null: false
+    t.index ["status_id", "task_id"], name: "index_statuses_tasks_on_status_id_and_task_id"
+    t.index ["task_id", "status_id"], name: "index_statuses_tasks_on_task_id_and_status_id"
   end
 
   create_table "taggings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_14_082922) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_14_123446) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -434,8 +434,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_14_082922) do
     t.datetime "updated_at", null: false
     t.date "start_date"
     t.date "end_date"
-    t.uuid "board_id", null: false
-    t.index ["board_id"], name: "index_tasks_on_board_id"
     t.index ["product_id"], name: "index_tasks_on_product_id"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
@@ -609,7 +607,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_14_082922) do
   add_foreign_key "statuses", "users"
   add_foreign_key "taggings", "tickets"
   add_foreign_key "taggings", "users"
-  add_foreign_key "tasks", "boards"
   add_foreign_key "tasks", "products"
   add_foreign_key "tasks", "users"
   add_foreign_key "tickets", "groupwares"


### PR DESCRIPTION
This pull request introduces significant changes to the task and board management system by decoupling tasks from boards and associating them directly with products and statuses. The changes simplify the data model, improve flexibility, and update the user interface accordingly. Below is a summary of the most important changes, grouped by theme.

### Backend Changes

#### Decoupling Tasks from Boards
* Removed the `board_id` association from the `Task` model and its related references, replacing it with a direct association to `statuses` using a many-to-many relationship (`app/models/task.rb`, `app/models/status.rb`, `app/models/board.rb`). [[1]](diffhunk://#diff-4095b65754098dce7229824782d43e80a7cb3f0fe45aa245102593760b51a24bL4) [[2]](diffhunk://#diff-4095b65754098dce7229824782d43e80a7cb3f0fe45aa245102593760b51a24bR19) [[3]](diffhunk://#diff-b8b0d989b8031e6690947f5a1117fa51873f60a213b202a7e97b15bd873c2f08R7) [[4]](diffhunk://#diff-6966eff600fcdd4af90f75552b92666591245211c7e1b6163176dfaa7cf474cdL4)

* Updated the `TasksController` to remove references to boards, including the `set_board` method and `board_id` parameters in task-related actions (`app/controllers/tasks_controller.rb`). [[1]](diffhunk://#diff-de1aaaf7a00c963e6a5e77045d8cbdafa5ebc81e1250a7ea1862a51d824e9945L4-R33) [[2]](diffhunk://#diff-de1aaaf7a00c963e6a5e77045d8cbdafa5ebc81e1250a7ea1862a51d824e9945L107-R114)

#### Refactoring Task Queries
* Adjusted task queries in the `ProductController` to work without boards, including changes to filtering, grouping, and counting tasks by status (`app/controllers/product_controller.rb`). [[1]](diffhunk://#diff-fb6d52c8e1f572d48fbc714f60fe113386ded18750f81b19ca971fbb4a4d9996L28-R31) [[2]](diffhunk://#diff-fb6d52c8e1f572d48fbc714f60fe113386ded18750f81b19ca971fbb4a4d9996L44-R44) [[3]](diffhunk://#diff-fb6d52c8e1f572d48fbc714f60fe113386ded18750f81b19ca971fbb4a4d9996L77-R85)

### Frontend Changes

#### Updating Task Forms and Links
* Updated all task-related forms and links to remove `board_id` and use `product_id` directly, including creation, editing, and state updates (`app/views/tasks/_form.html.erb`, `app/views/tasks/edit.html.erb`, `app/views/tasks/_add_state.html.erb`, `app/views/tasks/_add_task.html.erb`). [[1]](diffhunk://#diff-3ebc696256c0d351f6984c90bc965625017e69e0dfbf57f353e07187f9ebb062L2-R2) [[2]](diffhunk://#diff-3ebc696256c0d351f6984c90bc965625017e69e0dfbf57f353e07187f9ebb062L30-R30) [[3]](diffhunk://#diff-83990a09260bea777ff01806fd2c45d0f1cf0a1f5fc8018a48b3362c943c71d4L2-R2) [[4]](diffhunk://#diff-beabfdc92130c5c5ed40e6a690f5530c34083bbcf00e6dc0de8ebd190172e4e2L5-R9) [[5]](diffhunk://#diff-e16894bc567060221ef40b573398f6eeae7872365cdb0c05275742c10afc605cL5-R5)

* Replaced `new_product_board_task_path` with `new_product_task_path` across views to reflect the updated task creation flow (`app/views/boards/_board_display.html.erb`, `app/views/product/_product_show_topbar.html.erb`). [[1]](diffhunk://#diff-e9e846a80245ac81fdab00b60e88b3b918c2eb7676696430b91bd5d0870ff7f2L16-L28) [[2]](diffhunk://#diff-ec69bea2de38cfcb08f367a91319c29e127497e63b26d3147508a2597cc2d436L21-R21)

#### Task Display Updates
* Replaced board-based task displays with product-based displays, including rendering individual task cards directly within the product view (`app/views/product/show.html.erb`, `app/views/tasks/_card.html.erb`). [[1]](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fL68-L72) [[2]](diffhunk://#diff-031c870f91b82dd6e8fdcc805d33511418bf103f5256588aaf1e678178c175dcL1-R1)

### Miscellaneous Updates
* Added error logging for task creation failures using Sentry and Rails logger (`app/controllers/tasks_controller.rb`).

These changes collectively simplify the task management system, making it more flexible and aligned with the product-centric workflow. The decoupling of tasks from boards allows for better scalability and adaptability in the application.