### PR TITLE
Simplify product show view: remove extra spacing, adjust card styles,…

### DIFF
--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -9,7 +9,6 @@
     <%= render 'product/product_show_first_column' %>
 
     
-    
     <!-- Second Column - Combined Status Cards -->
      <%= render 'product/product_show_second_column' %>
 
@@ -75,7 +74,7 @@
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-5 min-w-full">
 
         <% @tasks_by_status.each do |status, tasks| %>
-          <div class="bg-white dark:bg-gray-700 rounded px-2 py-2 min-w-[280px]">
+          <div class="bg-white dark:bg-gray-700 rounded px-2 py-2">
             <!-- Board Header -->
             <div class="flex justify-between items-center mb-2 mx-1">
               <div class="flex items-center">
@@ -86,7 +85,7 @@
             </div>
 
             <!-- Board Cards -->
-            <div class="grid gap-2">
+            <div class="grid gap-2 p-2">
               <% tasks.each do |task| %>
                 <%= render partial: 'tasks/card', locals: { task: task } %>
               <% end %>


### PR DESCRIPTION
… and add padding to task grids.

This pull request includes minor updates to the layout and styling of the `app/views/product/show.html.erb` file, with a focus on improving spacing and consistency in the UI.

### Layout and Styling Changes:

* Removed an unused empty line between the first and second column render calls to clean up the code structure. (`[app/views/product/show.html.erbL12](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fL12)`)
* Removed the `min-w-[280px]` class from the task status card containers to allow for more flexible sizing. (`[app/views/product/show.html.erbL78-R77](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fL78-R77)`)
* Added a `p-2` padding class to the board cards container to improve spacing and alignment within the task grid. (`[app/views/product/show.html.erbL89-R88](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fL89-R88)`)