### PR TITLE
Update task count display in task budget grid to use dynamic values

### DIFF
--- a/app/views/product/_task_budget.html.erb
+++ b/app/views/product/_task_budget.html.erb
@@ -2,7 +2,9 @@
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
     <div class="bg-white dark:bg-gray-800 p-2">
       <h3 class="text-sm font-light mb-2">Tasks</h3>
-      <p class="text-md font-semibold">10/20</p>
+      <p class="text-md font-semibold">
+        <%= product.tasks.joins(:statuses).where(statuses: { name: 'Closed' }).count %> / <%= product.tasks.count %>
+      </p>
     </div>
     <div class="bg-white dark:bg-gray-800 p-2">
       <h3 class="text-sm font-light mb-2">Budget</h3>


### PR DESCRIPTION
This pull request updates the task progress display in the `app/views/product/_task_budget.html.erb` file to dynamically calculate and show the number of completed tasks out of the total tasks.

**Changes to task progress display:**
* Updated the task progress `<p>` element to dynamically calculate the number of completed tasks (`statuses: { name: 'Closed' }`) and display it alongside the total task count.