### PR TITLE
Drive final

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,6 +4,8 @@ class Task < ApplicationRecord
   has_one_attached :image
   has_one_attached :file
   has_many :messages, dependent: :destroy
+  before_create :set_default_status
+
 
   resourcify
 
@@ -19,6 +21,12 @@ class Task < ApplicationRecord
   has_and_belongs_to_many :statuses, dependent: :destroy
   has_many :bugs
   has_rich_text :description
+
+
+  def set_default_status
+    status = Status.find_by(name: 'TO DO')
+    statuses << status if status
+  end
 
   private
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,7 +6,6 @@ class Task < ApplicationRecord
   has_many :messages, dependent: :destroy
   before_create :set_default_status
 
-
   resourcify
 
   has_many :role_users, through: :roles, class_name: 'User', source: :user
@@ -21,7 +20,6 @@ class Task < ApplicationRecord
   has_and_belongs_to_many :statuses, dependent: :destroy
   has_many :bugs
   has_rich_text :description
-
 
   def set_default_status
     status = Status.find_by(name: 'TO DO')


### PR DESCRIPTION
This pull request introduces a new callback to the `Task` model to set a default status when a task is created. The most important changes are as follows:

### New functionality for default status:

* [`app/models/task.rb`](diffhunk://#diff-4095b65754098dce7229824782d43e80a7cb3f0fe45aa245102593760b51a24bR7): Added a `before_create` callback (`set_default_status`) to ensure tasks are assigned a default status of "TO DO" upon creation, if such a status exists.
* [`app/models/task.rb`](diffhunk://#diff-4095b65754098dce7229824782d43e80a7cb3f0fe45aa245102593760b51a24bR24-R28): Defined the `set_default_status` method to implement the logic for assigning the default status.