### PR TITLE
Ticket inception from

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -15,6 +15,11 @@ class DashboardsController < ApplicationController
       session[:team_id] = team.id # Store the team ID in the session
       user_ids = team.users.pluck(:id)
 
+      tickets_from_inception = Ticket.joins(:users, :statuses)
+        .where(users: { id: user_ids })
+        .where.not(statuses: { name: %w[Declined Closed] })
+        .count
+
       tickets_last_30_days = Ticket.joins(:users)
         .where(users: { id: user_ids })
         .where('tickets.created_at >= ?', 30.days.ago)
@@ -101,11 +106,6 @@ class DashboardsController < ApplicationController
         .where(sla_tickets: { sla_resolution_deadline: 'Breached' })
         .joins(:project)
         .group('projects.title')
-        .count
-
-      tickets_from_inception = Ticket.joins(:users, :statuses)
-        .where(users: { id: user_ids })
-        .where.not(statuses: { name: %w[Declined Closed] })
         .count
 
       ticket_details = tickets_last_30_days.select(:issue, :subject, :created_at)

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -14,6 +14,7 @@ class DashboardsController < ApplicationController
     if team
       session[:team_id] = team.id # Store the team ID in the session
       user_ids = team.users.pluck(:id)
+
       tickets_last_30_days = Ticket.joins(:users)
         .where(users: { id: user_ids })
         .where('tickets.created_at >= ?', 30.days.ago)
@@ -102,6 +103,11 @@ class DashboardsController < ApplicationController
         .group('projects.title')
         .count
 
+      tickets_from_inception = Ticket.joins(:users, :statuses)
+        .where(users: { id: user_ids })
+        .where.not(statuses: { name: %w[Declined Closed] })
+        .count
+
       ticket_details = tickets_last_30_days.select(:issue, :subject, :created_at)
 
       stats = {
@@ -121,7 +127,9 @@ class DashboardsController < ApplicationController
         breached_resolution_tickets_per_project: breached_resolution_tickets_per_project,
         breached_tickets_resolved_per_assignee: breached_tickets_resolved_per_assignee,
         breached_resolution_resolved_tickets_per_project: breached_resolution_resolved_tickets_per_project,
-        ticket_details: ticket_details
+        ticket_details: ticket_details,
+        tickets_from_inception: tickets_from_inception
+
       }
 
       render json: stats

--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -154,7 +154,7 @@ class ProductController < ApplicationController
       # UserMailer.assign_product_email(product_user, @product, current_user, assigned_user).deliver_later
       # end
 
-      redirect_to @product, notice: "#{user.name}  was successfully assigned."
+      redirect_to product_path(@product), notice: "#{user.name}  was successfully assigned."
     end
   end
 
@@ -163,7 +163,7 @@ class ProductController < ApplicationController
     status = Status.find(params[:status_id])
     @product.statuses.clear
     @product.statuses << status
-    redirect_to @product, notice: 'Product status was successfully updated.'
+    redirect_to product_path(@product), notice: 'Product status was successfully updated.'
   end
 
   def remove_user

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -23,6 +23,13 @@
 
   <!-- Stats Section -->
   <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 gap-6 mb-8 mt-6">
+
+    <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
+      <a href="#" class="stat-card-link" data-type="tickets_from_inception" onclick="fetchTicketDetails('<%= @selected_team %>', 'tickets_from_inception')">
+        <%= render 'dashboards/stat_card', title: "Tickets from Inception (That are not Closed or Declined)", value: @stats[:tickets_from_inception], id: "tickets_from_inception"%>
+      </a>
+    </div>
+
     <!-- initial Breach -->
     <a href="#" class="stat-card-link" data-type="initial_response_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'initial_response_time_breached')">
       <%= render 'dashboards/stat_card', title: "Initial Response Time - Breached", value: @stats[:breached_tickets_last_30_days], id: "initial_response_time_breached", class: 'col-span-1' %>
@@ -233,6 +240,8 @@
         document.getElementById("target_resolution_time_breached_open").innerText = data.resolution_breached_open_last_30_days;
         document.getElementById("target_resolution_time_breached_closed").innerText = data.resolution_breached_closed_last_30_days;
         document.getElementById("no_sla_population").innerText = data.no_sla_tickets_last_30_days;
+        document.getElementById("tickets_from_inception").innerText = data.tickets_from_inception;
+
 
         // Refresh charts
         document.getElementById("responseTimeChart").innerHTML = "";


### PR DESCRIPTION
This pull request introduces a new metric, "Tickets from Inception," to the dashboards and makes minor improvements to the product controller. The most important changes include adding the logic to calculate and display the new metric, updating the dashboard view to include it, and refactoring some redirect paths in the product controller.

### Dashboard Enhancements:

* [`app/controllers/dashboards_controller.rb`](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5R17-R22): Added logic to calculate the "Tickets from Inception" metric, which counts tickets associated with a team that are not in "Declined" or "Closed" statuses. This metric is now included in the JSON response for the dashboard. [[1]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5R17-R22) [[2]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L124-R132)
* [`app/views/dashboards/index.html.erb`](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60R26-R32): Updated the dashboard view to display the "Tickets from Inception" metric as a new stat card. Also updated JavaScript to dynamically update this metric on the page. [[1]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60R26-R32) [[2]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60R243-R244)

### Product Controller Improvements:

* [`app/controllers/product_controller.rb`](diffhunk://#diff-fb6d52c8e1f572d48fbc714f60fe113386ded18750f81b19ca971fbb4a4d9996L157-R157): Updated redirect paths in `add_user` and `product_status` methods to use `product_path(@product)` instead of `@product` for consistency and clarity. [[1]](diffhunk://#diff-fb6d52c8e1f572d48fbc714f60fe113386ded18750f81b19ca971fbb4a4d9996L157-R157) [[2]](diffhunk://#diff-fb6d52c8e1f572d48fbc714f60fe113386ded18750f81b19ca971fbb4a4d9996L166-R166)