### PR TITLE
Linter fix gem data

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -23,11 +23,11 @@ class DashboardsController < ApplicationController
       tickets_from_inception_count = tickets_from_inception.count
 
       tickets_from_inception_by_status = Status
-                                           .left_outer_joins(tickets: [:users])
-                                           .where(users: { id: user_ids })
-                                           .where.not(statuses: { name: %w[Declined Closed Resolved] })
-                                           .group('statuses.name')
-                                           .count
+        .left_outer_joins(tickets: [:users])
+        .where(users: { id: user_ids })
+        .where.not(statuses: { name: %w[Declined Closed Resolved] })
+        .group('statuses.name')
+        .count
 
       tickets_last_30_days = Ticket.joins(:users)
         .where(users: { id: user_ids })

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -18,6 +18,12 @@ class DashboardsController < ApplicationController
       tickets_from_inception = Ticket.joins(:users, :statuses)
         .where(users: { id: user_ids })
         .where.not(statuses: { name: %w[Declined Closed] })
+        .distinct
+
+      tickets_from_inception_count = tickets_from_inception.count
+
+      tickets_from_inception_by_status = tickets_from_inception
+        .group('statuses.name')
         .count
 
       tickets_last_30_days = Ticket.joins(:users)
@@ -128,7 +134,8 @@ class DashboardsController < ApplicationController
         breached_tickets_resolved_per_assignee: breached_tickets_resolved_per_assignee,
         breached_resolution_resolved_tickets_per_project: breached_resolution_resolved_tickets_per_project,
         ticket_details: ticket_details,
-        tickets_from_inception: tickets_from_inception
+        tickets_from_inception: tickets_from_inception_count,
+        tickets_from_inception_by_status: tickets_from_inception_by_status
 
       }
 
@@ -219,17 +226,20 @@ class DashboardsController < ApplicationController
   private
 
   def default_stats
-    # Default statistics, assuming 'Default Team' is the default team
     default_team = Team.find_by(name: 'Default Team')
 
     if default_team
       user_ids = default_team.users.pluck(:id)
       {
-        total_tickets_last_30_days: Ticket.where(user_id: user_ids).where('created_at >= ?', 30.days.ago).count
+        total_tickets_last_30_days: Ticket.where(user_id: user_ids).where('created_at >= ?', 30.days.ago).count,
+        tickets_from_inception: 0,
+        tickets_from_inception_by_status: {}
       }
     else
       {
-        total_tickets_last_30_days: 0
+        total_tickets_last_30_days: 0,
+        tickets_from_inception: 0,
+        tickets_from_inception_by_status: {}
       }
     end
   end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -17,14 +17,17 @@ class DashboardsController < ApplicationController
 
       tickets_from_inception = Ticket.joins(:users, :statuses)
         .where(users: { id: user_ids })
-        .where.not(statuses: { name: %w[Declined Closed] })
+        .where.not(statuses: { name: %w[Declined Closed Resolved] })
         .distinct
 
       tickets_from_inception_count = tickets_from_inception.count
 
-      tickets_from_inception_by_status = tickets_from_inception
-        .group('statuses.name')
-        .count
+      tickets_from_inception_by_status = Status
+                                           .left_outer_joins(tickets: [:users])
+                                           .where(users: { id: user_ids })
+                                           .where.not(statuses: { name: %w[Declined Closed Resolved] })
+                                           .group('statuses.name')
+                                           .count
 
       tickets_last_30_days = Ticket.joins(:users)
         .where(users: { id: user_ids })

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -92,7 +92,18 @@
     <!-- target repair time not breach -->
       <div class="col-span-1 sm:col-span-5 md:col-span-5 lg:col-span-5">
         <a href="#" class="stat-card-link" data-type="tickets_from_inception" onclick="fetchTicketDetails('<%= @selected_team %>', 'tickets_from_inception')">
-          <%= render 'dashboards/stat_card', title: "Tickets from Inception (That are not Closed or Declined)", value: @stats[:tickets_from_inception], id: "tickets_from_inception"%>
+          <%= render 'dashboards/stat_card', title: "Total Open Tickets", value: @stats[:tickets_from_inception], id: "tickets_from_inception"%>
+          <div class="mt-2 text-sm" data-type="tickets_from_inception_by_status" id="tickets_from_inception_by_status">
+            <% if @stats[:tickets_from_inception_by_status].present? %>
+              <% @stats[:tickets_from_inception_by_status].each do |status, count| %>
+                <div>
+                  <span class="font-semibold"><%= status %>:</span> <%= count %>
+                </div>
+              <% end %>
+            <% else %>
+              <div class="text-gray-400">No status breakdown available.</div>
+            <% end %>
+          </div>
         </a>
       </div>
 
@@ -254,6 +265,34 @@
         document.getElementById("target_resolution_time_breached_closed").innerText = data.resolution_breached_closed_last_30_days;
         document.getElementById("no_sla_population").innerText = data.no_sla_tickets_last_30_days;
         document.getElementById("tickets_from_inception").innerText = data.tickets_from_inception;
+
+        const container = document.getElementById("tickets_from_inception_by_status");
+        container.innerHTML = ""; // Clear existing content
+
+        const statusData = data.tickets_from_inception_by_status;
+
+        if (statusData && Object.keys(statusData).length > 0) {
+          let statuses = Object.keys(statusData);
+          let counts = Object.values(statusData);
+
+          let html = `
+              <table class="min-w-full border text-center">
+                <thead>
+                  <tr>
+                    ${statuses.map(status => `<th class="px-2 py-1 border-b font-semibold">${status}</th>`).join('')}
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    ${counts.map(count => `<td class="px-2 py-1 border-b">${count}</td>`).join('')}
+                  </tr>
+                </tbody>
+              </table>
+            `;
+          container.innerHTML = html;
+        } else {
+          container.innerHTML = `<div class="text-gray-400">No status breakdown available.</div>`;
+        }
 
 
         // Refresh charts

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -22,68 +22,81 @@
 
 
   <!-- Stats Section -->
-  <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 gap-6 mb-8 mt-6">
+  <div class="grid sm:grid-cols-5 md:grid-cols-5 lg:grid-cols-5 gap-6 mb-8 mt-6">
 
-    <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
-      <a href="#" class="stat-card-link" data-type="tickets_from_inception" onclick="fetchTicketDetails('<%= @selected_team %>', 'tickets_from_inception')">
-        <%= render 'dashboards/stat_card', title: "Tickets from Inception (That are not Closed or Declined)", value: @stats[:tickets_from_inception], id: "tickets_from_inception"%>
+    <div class="col-span-1 sm:col-span-5 md:col-span-5 lg:col-span-5">
+      <a href="#" class="stat-card-link" data-type="total_tickets_last_30_days" onclick="fetchTicketDetails('<%= @selected_team %>', 'total_tickets_last_30_days')">
+        <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days"%>
       </a>
     </div>
-
+    <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
     <!-- initial Breach -->
-    <a href="#" class="stat-card-link" data-type="initial_response_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'initial_response_time_breached')">
-      <%= render 'dashboards/stat_card', title: "Initial Response Time - Breached", value: @stats[:breached_tickets_last_30_days], id: "initial_response_time_breached", class: 'col-span-1' %>
-     </a>
+      <a href="#" class="stat-card-link" data-type="initial_response_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'initial_response_time_breached')">
+        <%= render 'dashboards/stat_card', title: "Initial Response Time - Breached", value: @stats[:breached_tickets_last_30_days], id: "initial_response_time_breached", class: 'col-span-1' %>
+       </a>
+    </div>
+    <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
     <!-- initial Not Breach -->
-    <a href="#" class="stat-card-link" data-type="initial_response_time_not_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'initial_response_time_not_breached')">
-      <%= render 'dashboards/stat_card', title: "Initial Response Time - Not Breached", value: @stats[:not_breached_tickets_last_30_days], id: "initial_response_time_not_breached", class: 'col-span-1'  %>
+      <a href="#" class="stat-card-link" data-type="initial_response_time_not_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'initial_response_time_not_breached')">
+        <%= render 'dashboards/stat_card', title: "Initial Response Time - Not Breached", value: @stats[:not_breached_tickets_last_30_days], id: "initial_response_time_not_breached", class: 'col-span-1'  %>
+      </a>
+    </div>
+    <a href="#" class="stat-card-link" data-type="no_sla_population" onclick="fetchTicketDetails('<%= @selected_team %>', 'no_sla_population')">
+      <%= render 'dashboards/stat_card', title: "No SLA-(NEW FEATURE)", value: @stats[:no_sla_tickets_last_30_days], id: "no_sla_population", class: 'col-span-1'  %>
     </a>
     <!-- target repair time breach -->
-    <div>
-      <a href="#" class="stat-card-link" data-type="target_repair_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached')">
-        <%= render 'dashboards/stat_card', title: "Target Repair Time - Breached", value: @stats[:response_breached_tickets_last_30_days], id: "target_repair_time_breached", class: 'col-span-1'  %>
-      </a>
-      <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
-        <a href="#" class="stat-card-link" data-type="target_repair_time_breached_open" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached_open')">
-          <%= render 'dashboards/stat_card', title: "(Open)", value: @stats[:response_breached_tickets_open_last_30_days], id: "target_repair_time_breached_open", class: 'col-span-1'  %>
-        </a>
-        <a href="#" class="stat-card-link" data-type="target_repair_time_breached_closed" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached_closed')">
-          <%= render 'dashboards/stat_card', title: "(Closed)", value: @stats[:response_breached_tickets_closed_last_30_days], id: "target_repair_time_breached_closed", class: 'col-span-1'  %>
-        </a>
+    <div class="col-span-1 sm:col-span-5 md:col-span-5 lg:col-span-5">
+      <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 gap-6">
+        <div>
+        <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
+          <a href="#" class="stat-card-link" data-type="target_repair_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached')">
+            <%= render 'dashboards/stat_card', title: "Target Repair Time - Breached", value: @stats[:response_breached_tickets_last_30_days], id: "target_repair_time_breached", class: 'col-span-1'  %>
+          </a>
+          <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
+            <a href="#" class="stat-card-link" data-type="target_repair_time_breached_open" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached_open')">
+              <%= render 'dashboards/stat_card', title: "(Open)", value: @stats[:response_breached_tickets_open_last_30_days], id: "target_repair_time_breached_open", class: 'col-span-1'  %>
+            </a>
+            <a href="#" class="stat-card-link" data-type="target_repair_time_breached_closed" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_breached_closed')">
+              <%= render 'dashboards/stat_card', title: "(Closed)", value: @stats[:response_breached_tickets_closed_last_30_days], id: "target_repair_time_breached_closed", class: 'col-span-1'  %>
+            </a>
+          </div>
+        </div>
+        </div>
+        <div>
+        <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
+          <a href="#" class="stat-card-link" data-type="target_resolution_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached')">
+            <%= render 'dashboards/stat_card', title: "Target Resolution Time - Breached", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
+          </a>
+          <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
+            <a href="#" class="stat-card-link" data-type="target_resolution_time_breached_open" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached_open')">
+              <%= render 'dashboards/stat_card', title: "(Open)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached_open", class: 'col-span-1'  %>
+            </a>
+            <a href="#" class="stat-card-link" data-type="target_resolution_time_breached_closed" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached_open')">
+              <%= render 'dashboards/stat_card', title: "(Closed)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached_closed", class: 'col-span-1'  %>
+            </a>
+          </div>
+        </div>
+        </div>
       </div>
     </div>
-    <div>
-      <a href="#" class="stat-card-link" data-type="target_resolution_time_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached')">
-        <%= render 'dashboards/stat_card', title: "Target Resolution Time - Breached", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached", class: 'col-span-1'  %>
-      </a>
-      <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
-        <a href="#" class="stat-card-link" data-type="target_resolution_time_breached_open" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached_open')">
-          <%= render 'dashboards/stat_card', title: "(Open)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached_open", class: 'col-span-1'  %>
-        </a>
-        <a href="#" class="stat-card-link" data-type="target_resolution_time_breached_closed" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_breached_open')">
-          <%= render 'dashboards/stat_card', title: "(Closed)", value: @stats[:resolution_breached_tickets_last_30_days], id: "target_resolution_time_breached_closed", class: 'col-span-1'  %>
-        </a>
-      </div>
-    </div>
-    <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
-        <div class="grid sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-3 gap-6">
+      <div class="col-span-1 sm:col-span-5 md:col-span-5 lg:col-span-5">
+        <div class="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 gap-6">
           <a href="#" class="stat-card-link" data-type="target_repair_time_not_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_repair_time_not_breached')">
             <%= render 'dashboards/stat_card', title: "Target Repair Time - Not Breached", value: @stats[:not_response_breached_tickets_last_30_days], id: "target_repair_time_not_breached", class: 'col-span-1'  %>
           </a>
           <a href="#" class="stat-card-link" data-type="target_resolution_time_not_breached" onclick="fetchTicketDetails('<%= @selected_team %>', 'target_resolution_time_not_breached')">
             <%= render 'dashboards/stat_card', title: "Target Resolution Time - Not Breached", value: @stats[:not_resolution_breached_tickets_last_30_days], id: "target_resolution_time_not_breached", class: 'col-span-1'  %>
           </a>
-          <a href="#" class="stat-card-link" data-type="no_sla_population" onclick="fetchTicketDetails('<%= @selected_team %>', 'no_sla_population')">
-            <%= render 'dashboards/stat_card', title: "No SLA-(NEW FEATURE)", value: @stats[:no_sla_tickets_last_30_days], id: "no_sla_population", class: 'col-span-1'  %>
-          </a>
         </div>
       </div>
     <!-- target repair time not breach -->
-      <div class="col-span-1 sm:col-span-2 md:col-span-2 lg:col-span-2">
-          <a href="#" class="stat-card-link" data-type="total_tickets_last_30_days" onclick="fetchTicketDetails('<%= @selected_team %>', 'total_tickets_last_30_days')">
-            <%= render 'dashboards/stat_card', title: "Total Tickets Last 30 days", value: @stats[:total_tickets_last_30_days], id: "total_tickets_last_30_days"%>
-          </a>
-      </div>      
+      <div class="col-span-1 sm:col-span-5 md:col-span-5 lg:col-span-5">
+        <a href="#" class="stat-card-link" data-type="tickets_from_inception" onclick="fetchTicketDetails('<%= @selected_team %>', 'tickets_from_inception')">
+          <%= render 'dashboards/stat_card', title: "Tickets from Inception (That are not Closed or Declined)", value: @stats[:tickets_from_inception], id: "tickets_from_inception"%>
+        </a>
+      </div>
+
+
   </div>
 
   <!-- Charts Section -->


### PR DESCRIPTION
This pull request enhances the dashboard by adding a breakdown of tickets by status, improving the display of statistics, and refining the layout for better usability. The most important changes include adjustments to the `fetch_stats` method to calculate ticket counts by status, updates to the default statistics, and improvements to the dashboard's HTML structure and JavaScript for dynamic rendering.

### Backend Changes

* **Enhancements to Ticket Statistics**:
  - Updated the `fetch_stats` method in `dashboards_controller.rb` to include a breakdown of tickets by status (`tickets_from_inception_by_status`) and excluded "Resolved" tickets from the count. Added distinct ticket counts and grouped them by status. [[1]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L20-R29) [[2]](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L131-R141)
  - Modified the `default_stats` method to include default values for `tickets_from_inception` and `tickets_from_inception_by_status`.

### Frontend Changes

* **Dashboard Layout and Styling**:
  - Adjusted the grid structure in `index.html.erb` to accommodate additional statistics and improve layout organization. [[1]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L25-R51) [[2]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60R64-R66) [[3]](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L68-R110)

* **Dynamic Rendering of Ticket Status Breakdown**:
  - Added JavaScript logic to dynamically render a table displaying the breakdown of tickets by status in the `tickets_from_inception_by_status` section. This includes handling cases where no breakdown data is available.