### PR TITLE
Update product grid to display groupware names instead of IDs.

### DIFF
--- a/app/views/product/_add_statuses.html.erb
+++ b/app/views/product/_add_statuses.html.erb
@@ -1,6 +1,6 @@
     <%= form_with url: product_status_product_path(@product), local: true do %>
         <div class="relative flex flex-col gap-2">
-            <%= select_tag :status_id, options_for_select(Status.where(name: ['Development','User Acceptance Test','Pilot','Quality Assurance','Deploy','Production']).pluck(:name, :id)), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
-            <%= submit_tag "UPDATE", class: 'w-full font-semibold bg-blue-500 hover:bg-blue-600 text-white p-3 rounded-lg mt-2' %>
+            <%= select_tag :status_id, options_for_select(Status.where(name: ['Development','User Acceptance Test','Pilot','Quality Assurance','Deploy','Production']).pluck(:name, :id)), class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
+            <%= submit_tag "UPDATE", class: 'font-semibold bg-blue-500 hover:bg-blue-600 text-white p-3 rounded-lg mt-2' %>
         </div>
     <% end %>

--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -13,8 +13,8 @@
 <%= render 'product/product_show_topbar' %>
 
 <div class="bg-white max-w-full dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
-<%= render 'layouts/alert' %>
-  <div class="gap-6">
+  <%= render 'layouts/alert' %>
+  <div class="gap-6 flex justify-between">
     <!-- First Column -->
 
     <!-- Fourth Column -->
@@ -39,6 +39,12 @@
         <% end %>
       </div>
     </div>
+    <% if current_user.has_role?(:admin) %>
+      <div class="px-16 grid grid-cols-[auto_1fr_auto] gap-3 sm:gap-4 col-span-1">
+        <!-- show added documents name and download button -->
+       <%= render partial: 'product/add_statuses', locals: { product: @product } %>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -119,7 +119,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_21_071715) do
     t.uuid "groupware_id"
     t.uuid "script_id"
     t.string "label"
-    t.uuid "defect_id"
+    t.uuid "defect_id", null: false
     t.index ["defect_id"], name: "index_bugs_on_defect_id"
     t.index ["groupware_id"], name: "index_bugs_on_groupware_id"
     t.index ["script_id"], name: "index_bugs_on_script_id"
@@ -155,15 +155,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_21_071715) do
     t.index ["project_id"], name: "index_comments_on_project_id"
     t.index ["ticket_id"], name: "index_comments_on_ticket_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
-  end
-
-  create_table "commonly_selected_clients", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
-    t.uuid "client_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["client_id"], name: "index_commonly_selected_clients_on_client_id"
-    t.index ["user_id"], name: "index_commonly_selected_clients_on_user_id"
   end
 
   create_table "defects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -535,6 +526,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_21_071715) do
     t.uuid "client_id"
     t.boolean "active", default: true
     t.uuid "location_id"
+    t.string "position"
     t.index ["client_id"], name: "index_users_on_client_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -586,8 +578,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_21_071715) do
   add_foreign_key "comments", "projects"
   add_foreign_key "comments", "tickets"
   add_foreign_key "comments", "users"
-  add_foreign_key "commonly_selected_clients", "clients"
-  add_foreign_key "commonly_selected_clients", "users"
   add_foreign_key "defects", "products"
   add_foreign_key "defects", "users"
   add_foreign_key "documents", "products"


### PR DESCRIPTION
This pull request includes updates to the `product` views to improve UI and conditional rendering, as well as database schema changes to enforce constraints and clean up unused tables. Below are the most important changes grouped by theme:

### UI Improvements in Product Views:
* [`app/views/product/_add_statuses.html.erb`](diffhunk://#diff-6d5aeb9ee2ab403ad8dbaa3483006de1242a1141949889c1e0951504e2a25845L3-R4): Adjusted the CSS classes for the `select_tag` and `submit_tag` to improve layout consistency. Removed unnecessary width and alignment classes.
* [`app/views/product/show.html.erb`](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fL17-R17): Added a `flex justify-between` class to a container for better alignment and spacing.
* [`app/views/product/show.html.erb`](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fR42-R47): Added conditional rendering to display an admin-only section for managing product statuses, using the `add_statuses` partial.

### Database Schema Changes:
* [`db/schema.rb`](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L122-R122): Made the `defect_id` column in the `bugs` table non-nullable to enforce data integrity.
* [`db/schema.rb`](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L160-L168): Removed the `commonly_selected_clients` table and its associated foreign keys, as it is no longer in use. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L160-L168) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L589-L590)
* [`db/schema.rb`](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R529): Added a new `position` column to the `users` table to store additional user metadata.