### PR TITLE
Refine "Tickets from Inception" metric handling: fix key naming incon…

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -137,7 +137,7 @@ class DashboardsController < ApplicationController
         breached_tickets_resolved_per_assignee: breached_tickets_resolved_per_assignee,
         breached_resolution_resolved_tickets_per_project: breached_resolution_resolved_tickets_per_project,
         ticket_details: ticket_details,
-        tickets_from_inception: tickets_from_inception_count,
+        tickets_from_inception_count: tickets_from_inception_count,
         tickets_from_inception_by_status: tickets_from_inception_by_status
 
       }
@@ -195,6 +195,9 @@ class DashboardsController < ApplicationController
           .where(statuses: { name: %w[Closed Resolved] })
       when 'target_resolution_time_not_breached'
         @tickets = @tickets.where(sla_tickets: { sla_resolution_deadline: ['Not Breached', nil] })
+      when 'tickets_from_inception_by_status'
+        @tickets = Status.left_outer_joins(tickets: [:users]).where(users: { id: user_ids }).where.not(statuses: { name: %w[Declined Closed Resolved] }).group('statuses.name')
+
       when 'total_tickets_last_30_days'
         # No additional filtering needed
       end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -91,8 +91,8 @@
       </div>
     <!-- target repair time not breach -->
       <div class="col-span-1 sm:col-span-5 md:col-span-5 lg:col-span-5">
-        <a href="#" class="stat-card-link" data-type="tickets_from_inception" onclick="fetchTicketDetails('<%= @selected_team %>', 'tickets_from_inception')">
-          <%= render 'dashboards/stat_card', title: "Total Open Tickets from Inceptions( Minus Closed, Resolved or Decline)", value: @stats[:tickets_from_inception], id: "tickets_from_inception"%>
+        <a href="#" class="stat-card-link" data-type="tickets_from_inception_count" onclick="fetchTicketDetails('<%= @selected_team %>', 'tickets_from_inception_count')">
+          <%= render 'dashboards/stat_card', title: "Total Open Tickets from Inceptions( Minus Closed, Resolved or Decline)", value: @stats[:tickets_from_inception], id: "tickets_from_inception_count"%>
           <div class="mt-2 text-sm" data-type="tickets_from_inception_by_status" id="tickets_from_inception_by_status">
             <% if @stats[:tickets_from_inception_by_status].present? %>
               <% @stats[:tickets_from_inception_by_status].each do |status, count| %>
@@ -264,7 +264,7 @@
         document.getElementById("target_resolution_time_breached_open").innerText = data.resolution_breached_open_last_30_days;
         document.getElementById("target_resolution_time_breached_closed").innerText = data.resolution_breached_closed_last_30_days;
         document.getElementById("no_sla_population").innerText = data.no_sla_tickets_last_30_days;
-        document.getElementById("tickets_from_inception").innerText = data.tickets_from_inception;
+        document.getElementById("tickets_from_inception_count").innerText = data.tickets_from_inception_count;
 
         const container = document.getElementById("tickets_from_inception_by_status");
         container.innerHTML = ""; // Clear existing content
@@ -276,7 +276,7 @@
           let counts = Object.values(statusData);
 
           let html = `
-              <table class="min-w-full border text-center">
+              <table class="min-w-full border text-center bg-white dark:bg-gray-700">
                 <thead>
                   <tr>
                     ${statuses.map(status => `<th class="px-2 py-1 border-b font-bold text-md">${status}</th>`).join('')}


### PR DESCRIPTION
…sistencies, update logic for status grouping, and enhance table styling.

This pull request includes updates to the `dashboards` feature, focusing on improving naming consistency, adding a new filter for ticket statuses, and enhancing the UI for better readability. Below is a summary of the most important changes:

### Backend Updates:
* **Renaming for Consistency**: Updated the key `tickets_from_inception` to `tickets_from_inception_count` in the `fetch_stats` method for improved clarity and alignment with naming conventions. (`app/controllers/dashboards_controller.rb`, [app/controllers/dashboards_controller.rbL140-R140](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5L140-R140))
* **New Filter for Ticket Statuses**: Added a new filter, `tickets_from_inception_by_status`, to fetch tickets grouped by their status, excluding specific statuses like `Declined`, `Closed`, and `Resolved`. (`app/controllers/dashboards_controller.rb`, [app/controllers/dashboards_controller.rbR198-R200](diffhunk://#diff-8176f7cf6d68ad6630418f9d9faf7be510e5fb6e5e0bb535fe36efe3ed36bcb5R198-R200))

### Frontend Updates:
* **Stat Card Updates**: Refactored the `data-type` and `id` attributes in the stat card to use the new `tickets_from_inception_count` key, ensuring consistency with backend changes. (`app/views/dashboards/index.html.erb`, [app/views/dashboards/index.html.erbL94-R95](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L94-R95))
* **Dynamic Updates**: Modified JavaScript references to update `tickets_from_inception_count` instead of the old key `tickets_from_inception`. (`app/views/dashboards/index.html.erb`, [app/views/dashboards/index.html.erbL267-R267](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L267-R267))
* **UI Enhancement**: Improved the appearance of the status table by adding background color classes for better readability in both light and dark modes. (`app/views/dashboards/index.html.erb`, [app/views/dashboards/index.html.erbL279-R279](diffhunk://#diff-33f2a03c3c8eec9a7aabd1f533d5dbf4c2242f19733950bc7c7422cf925b8b60L279-R279))