### PR TITLE
Refine product grid styling with adjusted border thickness and set de…

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -11,6 +11,7 @@ class Product < ApplicationRecord
   accepts_nested_attributes_for :documents, allow_destroy: true
   has_one_attached :image
   has_many :defects, dependent: :nullify
+  before_create :set_default_status
 
   has_rich_text :content
 
@@ -32,6 +33,11 @@ class Product < ApplicationRecord
 
   def craftsilicon_users
     User.where('email LIKE ANY (array[?, ?, ?]) AND active = ?', '%@craftsilicon.com', '%@craftsilicon.co.tz', '%@little.africa', true)
+  end
+
+  def set_default_status
+    status = Status.find_by(name: 'Development')
+    statuses << status if status
   end
 
   private

--- a/app/views/product/_product_grid.html.erb
+++ b/app/views/product/_product_grid.html.erb
@@ -16,7 +16,7 @@
             </p>
 
           </div>
-          <div class="rounded-full border p-2 border-white bg-white dark:bg-gray-700">
+          <div class="rounded-full border border-2 p-2 border-white bg-white dark:bg-gray-700">
             <p class="text-sm font-semibold"><%= product.statuses.first&.name %></p>
           </div>
         </div>


### PR DESCRIPTION
…fault status for products on creation.
This pull request introduces a new feature to set a default status for products upon creation, along with a minor UI adjustment in the product grid view. The key changes include adding a callback to set the default status in the `Product` model and updating the CSS for the status display.

### Model improvements:

* Added a `before_create` callback in `Product` to set a default status (`set_default_status`) to "Development" if it exists in the `statuses` table. (`app/models/product.rb`, [[1]](diffhunk://#diff-aa055f17937e9bfdcdd1b8bd3fe76c7cb960c967747b519f0fc1c04c3253dafaR14) [[2]](diffhunk://#diff-aa055f17937e9bfdcdd1b8bd3fe76c7cb960c967747b519f0fc1c04c3253dafaR38-R42)

### UI adjustments:

* Updated the CSS class in `_product_grid.html.erb` to add a thicker border (`border-2`) around the status display. (`app/views/product/_product_grid.html.erb`, [app/views/product/_product_grid.html.erbL19-R19](diffhunk://#diff-42776763b1fc6b4d5a0494719fca6f7f282121c55bac7ccae0a7cde9400d4943L19-R19))
