### PR TITLE
Adjust pagination logic in `manager_active` to increase `per_page` li…

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -82,7 +82,7 @@ class UsersController < ApplicationController
   end
 
   def manager_active
-    per_page = 1
+    per_page = 50
     page = params[:page].to_i.positive? ? params[:page].to_i : 1
 
     @active_users_manager = User.joins(:roles)


### PR DESCRIPTION
…mit from 1 to 50.
This pull request modifies the pagination behavior in the `manager_active` method of the `UsersController` to display more results per page.

* [`app/controllers/users_controller.rb`](diffhunk://#diff-cfdccd0a9d5df5a43aaad2a35d36ebbe187c52ad5fdc9846fa189d04537adb6eL85-R85): Updated the `per_page` variable in the `manager_active` method from `1` to `50`, increasing the number of users displayed per page.