### PR TITLE
Refine task board rendering: implement ordered statuses, improve SVG …

### DIFF
--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -59,29 +59,36 @@
     <div class="h-screen p-2 overflow-x-auto">
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-5 min-w-full">
 
-        <% @tasks_by_status.each do |status, tasks| %>
+        <% ordered_statuses = ['Reopened', 'TO DO', 'In Progress', 'On-Hold', 'Await Client Information',
+                               'Failed-QA', 'QA-testing', 'Awaiting Build', 'Awaiting Client API',
+                               'Blocked', 'Resolved', 'Closed'] %>
+
+        <% ordered_statuses.each do |status| %>
+          <% tasks = @tasks_by_status[status] || [] %>
+          <% next if tasks.empty? %>
           <div class="bg-white dark:bg-gray-700 rounded px-2 py-2">
             <!-- Board Header -->
             <div class="flex justify-between items-center mb-2 mx-1">
               <div class="flex items-center">
                 <h2 class="text-sm w-max px-2 py-1 rounded capitalize flex items-center gap-2">
-                  <% if status == "TO DO" %>
+                  <% case status %>
+                  <% when "TO DO" %>
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m.75 12 3 3m0 0 3-3m-3 3v-6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
                     </svg>
-                    <% elsif status == 'In Progress' %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-                      </svg>
-                    <% elsif status == 'Under Development'%>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
-                    <% elsif status == 'Blocked' %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="" class="size-6">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.25-8.25-3.286Zm0 13.036h.008v.008H12v-.008Z" />
-                      </svg>
+                  <% when "In Progress" %>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                     </svg>
-                <% end %>
+                  <% when "Under Development" %>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+                    </svg>
+                  <% when "Blocked" %>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.25-8.25-3.286Zm0 13.036h.008v.008H12v-.008Z" />
+                    </svg>
+                  <% end %>
                   <%= status %>
                 </h2>
                 <p class="text-xs ml-1 border rounded-full px-2 py-1"><%= tasks.count %></p>
@@ -97,6 +104,7 @@
             </div>
           </div>
         <% end %>
+
 
       </div>
     </div>


### PR DESCRIPTION
…conditionals with `case` structure, and adjust empty-task handling for cleaner display.
This pull request improves the task display logic on the product show page by introducing an ordered status list and refactoring the code to enhance readability and maintainability.

### Task display logic improvements:

* Introduced an `ordered_statuses` array to ensure tasks are displayed in a consistent, predefined order. Tasks are now iterated based on this order, and empty task groups are skipped. (`app/views/product/show.html.erb`, [app/views/product/show.html.erbL62-R89](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fL62-R89))
* Refactored the conditional rendering of SVG icons for task statuses by replacing multiple `if`/`elsif` statements with a `case` statement, making the code more concise and easier to extend. (`app/views/product/show.html.erb`, [app/views/product/show.html.erbL62-R89](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fL62-R89))

### Code cleanup:

* Removed an unused empty line for better formatting. (`app/views/product/show.html.erb`, [app/views/product/show.html.erbR108](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fR108))