### PR TITLE
Refine task board views: implement categorized and uncategorized task…

### DIFF
--- a/app/views/product/show.html.erb
+++ b/app/views/product/show.html.erb
@@ -63,9 +63,13 @@
                                'Failed-QA', 'QA-testing', 'Awaiting Build', 'Awaiting Client API',
                                'Blocked', 'Resolved', 'Closed'] %>
 
+        <% categorized_statuses = @tasks_by_status.slice(*ordered_statuses) %>
+        <% uncategorized_statuses = @tasks_by_status.except(*ordered_statuses) %>
+
         <% ordered_statuses.each do |status| %>
-          <% tasks = @tasks_by_status[status] || [] %>
+          <% tasks = categorized_statuses[status] || [] %>
           <% next if tasks.empty? %>
+
           <div class="bg-white dark:bg-gray-700 rounded px-2 py-2">
             <!-- Board Header -->
             <div class="flex justify-between items-center mb-2 mx-1">
@@ -104,6 +108,31 @@
             </div>
           </div>
         <% end %>
+
+        <% # Render Uncategorized Tasks %>
+        <% uncategorized_tasks = uncategorized_statuses.values.flatten.compact %>
+        <% if uncategorized_tasks.any? %>
+          <div class="bg-white dark:bg-gray-700 rounded px-2 py-2">
+            <div class="flex justify-between items-center mb-2 mx-1">
+              <div class="flex items-center">
+                <h2 class="text-sm w-max px-2 py-1 rounded capitalize flex items-center gap-2">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.25-8.25-3.286Zm0 13.036h.008v.008H12v-.008Z" />
+                  </svg>
+                  Uncategorized
+                </h2>
+                <p class="text-xs ml-1 border rounded-full px-2 py-1"><%= uncategorized_tasks.count %></p>
+              </div>
+            </div>
+
+            <div class="grid gap-2 p-2">
+              <% uncategorized_tasks.each do |task| %>
+                <%= render partial: 'tasks/card', locals: { task: task } %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+
 
 
       </div>


### PR DESCRIPTION
… rendering for improved status grouping and display.
This pull request enhances the task display on the product page by introducing a clear separation between categorized and uncategorized tasks. The changes improve the user interface by ensuring that uncategorized tasks are displayed in their own section, making the task board more organized and user-friendly.

### Improvements to task categorization and display:

* [`app/views/product/show.html.erb`](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fR66-R72): Introduced `categorized_statuses` and `uncategorized_statuses` variables to separate tasks into categorized and uncategorized groups. This ensures that tasks are handled more systematically.
* [`app/views/product/show.html.erb`](diffhunk://#diff-98bac786e8c93d9f07ce573fca3a3655daa7eb47a7317da0390a5cd929af317fR112-R136): Added a new section to render uncategorized tasks, including a header with a task count and a grid layout for displaying individual task cards.