### PR TITLE
Show allusers dropdown in the support desk manage users

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -22,6 +22,9 @@ export default class extends Controller {
     if (!this.menuTarget.classList.contains('hidden')) {
       document.addEventListener('click', this.boundClose);
     }
+
+    const svg = this.buttonTarget.querySelector('svg')
+    svg.classList.toggle('rotate-180')
   }
 
   close(event) {
@@ -31,6 +34,14 @@ export default class extends Controller {
     if (!button.contains(event.target) && !dropdown.contains(event.target)) {
       dropdown.classList.add('hidden');
       document.removeEventListener('click', this.boundClose);
+    }
+  }
+
+  hide(event) {
+    if (!this.element.contains(event.target) && !this.menuTarget.classList.contains('hidden')) {
+      this.menuTarget.classList.add('hidden')
+      const svg = this.buttonTarget.querySelector('svg')
+      svg.classList.remove('rotate-180')
     }
   }
 }

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -23,8 +23,8 @@ export default class extends Controller {
       document.addEventListener('click', this.boundClose);
     }
 
-    const svg = this.buttonTarget.querySelector('svg')
-    svg.classList.toggle('rotate-180')
+    const svg = this.buttonTarget.querySelector('svg');
+    svg.classList.toggle('rotate-180');
   }
 
   close(event) {
@@ -39,9 +39,9 @@ export default class extends Controller {
 
   hide(event) {
     if (!this.element.contains(event.target) && !this.menuTarget.classList.contains('hidden')) {
-      this.menuTarget.classList.add('hidden')
-      const svg = this.buttonTarget.querySelector('svg')
-      svg.classList.remove('rotate-180')
+      this.menuTarget.classList.add('hidden');
+      const svg = this.buttonTarget.querySelector('svg');
+      svg.classList.remove('rotate-180');
     }
   }
 }

--- a/app/javascript/controllers/expandable_list_controller.js
+++ b/app/javascript/controllers/expandable_list_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["initialList", "fullList", "showText", "hideText", "icon"]
+
+  toggle() {
+    this.fullListTarget.classList.toggle("hidden")
+    this.initialListTarget.classList.toggle("hidden")
+    this.showTextTarget.classList.toggle("hidden")
+    this.hideTextTarget.classList.toggle("hidden")
+    this.iconTarget.classList.toggle("rotate-180")
+  }
+}

--- a/app/javascript/controllers/expandable_list_controller.js
+++ b/app/javascript/controllers/expandable_list_controller.js
@@ -1,13 +1,13 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-  static targets = ["initialList", "fullList", "showText", "hideText", "icon"]
+  static targets = ['initialList', 'fullList', 'showText', 'hideText', 'icon']
 
   toggle() {
-    this.fullListTarget.classList.toggle("hidden")
-    this.initialListTarget.classList.toggle("hidden")
-    this.showTextTarget.classList.toggle("hidden")
-    this.hideTextTarget.classList.toggle("hidden")
-    this.iconTarget.classList.toggle("rotate-180")
+    this.fullListTarget.classList.toggle('hidden');
+    this.initialListTarget.classList.toggle('hidden');
+    this.showTextTarget.classList.toggle('hidden');
+    this.hideTextTarget.classList.toggle('hidden');
+    this.iconTarget.classList.toggle('rotate-180');
   }
 }

--- a/app/views/project/_assign_people.html.erb
+++ b/app/views/project/_assign_people.html.erb
@@ -12,9 +12,7 @@
         
         <!-- Full list (hidden by default) -->
         <div class="hidden mt-2" data-expandable-list-target="fullList">
-          <% @craft_silicon_users.each do |user| %>
-            <div class="py-1"><%= user.name %></div>
-          <% end %>
+          <%= @craft_silicon_users.map(&:name).join(", ") %>
         </div>
         
         <!-- Toggle button (only shows if more than 5 users) -->
@@ -46,9 +44,7 @@
         
         <!-- Full list (hidden by default) -->
         <div class="hidden mt-2" data-expandable-list-target="fullList">
-          <% @non_craft_silicon_users.each do |user| %>
-            <div class="py-1"><%= user.name %></div>
-          <% end %>
+          <%= @non_craft_silicon_users.map(&:name).join(", ") %>
         </div>
         
         <!-- Toggle button (only shows if more than 5 users) -->

--- a/app/views/project/_assign_people.html.erb
+++ b/app/views/project/_assign_people.html.erb
@@ -1,20 +1,72 @@
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-  <% if current_user.has_role? :admin or current_user.has_role?('project manager') or current_user.has_role?(:agent) %>
+  <% if current_user.has_role?(:admin) || current_user.has_role?('project manager') || current_user.has_role?(:agent) %>
     
     <!-- Craft Silicon Staff -->
-    <div>
+    <div data-controller="expandable-list">
       <h3 class="text-sm font-semibold mb-2">Craft Silicon Staff</h3>
-      <p class="text-sm ">
-        <%= @craft_silicon_users.first(5).map(&:name).join(", ") %>
-      </p>
+      <div class="text-sm">
+        <!-- Initial visible users -->
+        <div data-expandable-list-target="initialList">
+          <%= @craft_silicon_users.first(5).map(&:name).join(", ") %>
+        </div>
+        
+        <!-- Full list (hidden by default) -->
+        <div class="hidden mt-2" data-expandable-list-target="fullList">
+          <% @craft_silicon_users.each do |user| %>
+            <div class="py-1"><%= user.name %></div>
+          <% end %>
+        </div>
+        
+        <!-- Toggle button (only shows if more than 5 users) -->
+        <% if @craft_silicon_users.count > 5 %>
+          <button class="mt-1 flex items-center text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300" 
+                  data-action="expandable-list#toggle">
+            <span class="mr-1 text-sm">
+              <span data-expandable-list-target="showText">Show all</span>
+              <span class="hidden" data-expandable-list-target="hideText">Hide</span>
+            </span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transition-transform duration-200" 
+                 viewBox="0 0 20 20" fill="currentColor"
+                 data-expandable-list-target="icon">
+              <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+          </button>
+        <% end %>
+      </div>
     </div>
 
     <!-- Clients -->
-    <div>
+    <div data-controller="expandable-list">
       <h3 class="text-sm font-semibold mb-2">Clients</h3>
-      <p class="text-sm">
-        <%= @non_craft_silicon_users.first(5).map(&:name).join(", ") %>
-      </p>
+      <div class="text-sm">
+        <!-- Initial visible users -->
+        <div data-expandable-list-target="initialList">
+          <%= @non_craft_silicon_users.first(5).map(&:name).join(", ") %>
+        </div>
+        
+        <!-- Full list (hidden by default) -->
+        <div class="hidden mt-2" data-expandable-list-target="fullList">
+          <% @non_craft_silicon_users.each do |user| %>
+            <div class="py-1"><%= user.name %></div>
+          <% end %>
+        </div>
+        
+        <!-- Toggle button (only shows if more than 5 users) -->
+        <% if @non_craft_silicon_users.count > 5 %>
+          <button class="mt-1 flex items-center text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300" 
+                  data-action="expandable-list#toggle">
+            <span class="mr-1 text-sm">
+              <span data-expandable-list-target="showText">Show all</span>
+              <span class="hidden" data-expandable-list-target="hideText">Hide</span>
+            </span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 transition-transform duration-200" 
+                 viewBox="0 0 20 20" fill="currentColor"
+                 data-expandable-list-target="icon">
+              <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+          </button>
+        <% end %>
+      </div>
     </div>
 
   <% end %>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -12,6 +12,9 @@ module.exports = {
       fontFamily: {
         sans: ['Nunito Sans', ...defaultTheme.fontFamily.sans],
       },
+      rotate: {
+        '180': '180deg',
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
Right now, if there are more than 5 users, there is a drop down that allows a user to see a list of all users (Craft Silicon or non-craft silicon users) Who are for a specific service desk. Helps user to know how to manage them well. This references issue #1033 


[Screencast from 24-07-2025 11:46:14 ASUBUHI.webm](https://github.com/user-attachments/assets/fd6c046b-caf3-442c-b509-aeb06bb30357)
