### PR TITLE
Reposition commonly selected clients

### DIFF
--- a/app/views/data_center/cease_fire_report.html.erb
+++ b/app/views/data_center/cease_fire_report.html.erb
@@ -13,6 +13,7 @@
     <span class="text-xs text-red mt-1">
       (Leave the date field blank if you want all the data from inception to date*)
     </span>
+    <div id="flash-container"></div>
   </div>
 
   <!-- Right: Manage Button (admin only) -->
@@ -104,10 +105,10 @@
       </div>
       <div class="flex  flex-cols-2 gap-2 pt-10">
         <!-- Preselect commonly selected clients button -->
-        <button type="button" id="precheckCommonClientsBtn" class="text-sm border-2 border-green-500 text-green-600 hover:bg-green-600 hover:text-white px-3 py-2 rounded-lg transition duration-200">
+        <button type="button" id="precheckCommonClientsBtn" class="border-2 border-green-500 text-green-600 hover:bg-green-600 hover:text-white p-2 rounded-lg transition duration-200">
           Preselect Common Clients
         </button>
-        <%= f.submit "Generate Report", class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100 w-full sm:w-auto' %>
+        <%= f.submit "Generate Report", class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-lg text-slate-100 w-full sm:w-auto' %>
       </div>
     </div>
   <% end %>
@@ -187,19 +188,21 @@
         const data = await response.json();
         const commonIds = data.client_ids.map(id => id.toString());
 
+        if (commonIds.length === 0) {
+          showFlashNotice("No commonly selected clients found. Please click 'Manage common clients' to add them first.");
+          return; // stop execution
+        }
+
         document.querySelectorAll(".client-checkbox").forEach((checkbox) => {
           if (commonIds.includes(checkbox.value)) {
-            checkbox.checked = !commonClientsPreselected; // Toggle checked based on current state
+            checkbox.checked = !commonClientsPreselected;
           }
         });
 
-        // Update hidden fields + display input
         updateSelections("searchClient", "selectedClientsWrapper", "client-checkbox", "client_ids[]", "clientName");
-
-        // Show dropdown
         document.getElementById("clientDropdown").classList.remove("hidden");
 
-        // Toggle state and button text/style
+        // Toggle state and button appearance
         commonClientsPreselected = !commonClientsPreselected;
         if (commonClientsPreselected) {
           button.textContent = "Deselect Common Clients";
@@ -214,6 +217,21 @@
         alert("Failed to load common clients.");
       }
     });
+
+    // Helper function to display flash-like notice
+    function showFlashNotice(message) {
+      const flashDiv = document.createElement("div");
+      flashDiv.className = "flash-notice bg-yellow-100 border border-yellow-400 text-yellow-800 px-4 py-2 rounded mt-4";
+      flashDiv.textContent = message;
+
+      const target = document.getElementById("flash-container") || document.body;
+      target.prepend(flashDiv);
+
+      setTimeout(() => {
+        flashDiv.remove();
+      }, 5000);
+    }
+
 
 
     // Setup for "Status" dropdown

--- a/app/views/data_center/cease_fire_report.html.erb
+++ b/app/views/data_center/cease_fire_report.html.erb
@@ -58,11 +58,6 @@
           <div class="flex gap-2">
             <!-- Search Input -->
             <input type="text" id="searchClient" class="border border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-lg bg-slate-100 dark:bg-gray-900 text-gray-900 dark:text-slate-100 w-full px-4 py-2" placeholder="Search Client..." onkeyup="filterClientDropdown()">
-
-            <!-- Preselect commonly selected clients button -->
-            <button type="button" id="precheckCommonClientsBtn" class="text-sm border-2 border-green-500 text-green-600 hover:bg-green-600 hover:text-white px-3 py-2 rounded-lg transition duration-200">
-              Preselect Common Clients
-            </button>
           </div>
 
           <!-- Dropdown List -->
@@ -107,7 +102,11 @@
                      class: "border py-2 pl-4 pr-8 border-[#3F8CFF] hover:border-[#3A81EB] border-2 rounded-md dark:bg-gray-900" %>
 
       </div>
-      <div class="flex  flex-col gap-2 pt-10">
+      <div class="flex  flex-cols-2 gap-2 pt-10">
+        <!-- Preselect commonly selected clients button -->
+        <button type="button" id="precheckCommonClientsBtn" class="text-sm border-2 border-green-500 text-green-600 hover:bg-green-600 hover:text-white px-3 py-2 rounded-lg transition duration-200">
+          Preselect Common Clients
+        </button>
         <%= f.submit "Generate Report", class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-3 rounded font-bold rounded-lg text-slate-100 w-full sm:w-auto' %>
       </div>
     </div>


### PR DESCRIPTION
Re-positioned the commonly selected clients button to the extreme right side of the page.

Added a custom flash message that shows when there are no commonly selected clients in the system. This custom flash is removed from the DOM after 5 seconds.

[Screencast from 28-07-2025 10:22:44 ASUBUHI.webm](https://github.com/user-attachments/assets/7e0c2dd7-777c-43ff-9055-b757ec163648)

This PR references the issue #1040 