### PR TITLE
Refine Devise configuration: set `invitation_limit` to 15 for improve…

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -151,7 +151,7 @@ Devise.setup do |config|
   # You can change invitation_limit column for some users so they can send more
   # or less invitations, even with global invitation_limit = 0
   # Default: nil
-  config.invitation_limit = nil
+  config.invitation_limit = 15
 
   # The key to be used to check existing users when sending an invitation
   # and the regexp used to test it when validate_on_invite is not set.


### PR DESCRIPTION
…d invitation control.
This pull request updates the configuration for user invitations in the `Devise` initializer. The most important change is:

* [`config/initializers/devise.rb`](diffhunk://#diff-cb6e8126296dbc007e7625eee863de5c3213ed949b9999ea3418775f65826531L154-R154): Set the `invitation_limit` configuration to `15`, establishing a global limit on the number of invitations a user can send.