### PR TITLE
Fix error caused by the budget field being updated to type integer

### DIFF
--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -18,7 +18,7 @@ class ProductController < ApplicationController
         .where(
           "products.document_name ILIKE :q OR
           statuses.name ILIKE :q OR
-          products.budget ILIKE :q OR
+          CAST(products.budget AS TEXT) ILIKE :q OR
           action_text_rich_texts.body ILIKE :q OR
           EXISTS (
             SELECT 1 FROM clients


### PR DESCRIPTION
Projects search now works as intended after updating the filter to cast integers to text first to allow for smoother searching.

This issue references issue #1058 