### PR TITLE
Refine defect form: enhance project selection dropdown with client an…

### DIFF
--- a/app/views/defect/_form.html.erb
+++ b/app/views/defect/_form.html.erb
@@ -7,7 +7,15 @@
       </div>
       <div class="relative z-0 w-full mb-6 group">
         <%= f.label :client, ('Project Name *'), class: "capitalize block mb-6 text-sm font-medium" %>
-        <%= f.collection_select :product_id, Product.all, :id, :name, { prompt: "Select Project" }, class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500", required: true %>
+        <%= f.select :product_id,
+                     Product.includes(:client, :groupwares).map { |product|
+                       client_name = product.client&.name || "No Client"
+                       groupware_names = product.groupwares.any? ? product.groupwares.map(&:name).join(", ") : "No Software"
+                       ["#{client_name} - #{groupware_names}", product.id]
+                     },
+                     { prompt: "Select Project" },
+                     class: "border border-gray-300 rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:focus:ring-blue-500 dark:focus:border-blue-500",
+                     required: true %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
…d groupware details.
This pull request updates the project selection dropdown in the defect form to provide more context for each project. Instead of just showing the project name, the dropdown now displays both the client name and the associated groupware(s) for each project, making it easier for users to select the correct project.

Improvements to project selection in the defect form:

* Updated the `product_id` dropdown in `app/views/defect/_form.html.erb` to show each project's client name and groupware(s) in the format "Client Name - Groupware Names", improving clarity for users when selecting a project.