### PR TITLE
Refine product handling: update `budget` column type from `string` to…

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -34,7 +34,7 @@ class Product < ApplicationRecord
   end
 
   def set_default_status
-    status = Status.find_by(name: 'Development')
+    status = Status.find_by(name: 'Initiation')
     statuses << status if status
   end
 

--- a/app/views/data_center/sod_report.html.erb
+++ b/app/views/data_center/sod_report.html.erb
@@ -61,6 +61,7 @@
           <th class="border border-black px-4 py-2">Comment Added At</th> <!-- New Column -->
           <th class="border border-black px-4 py-2">Comment</th>
           <th class="border border-black px-4 py-2">Due Date</th>
+          <th class="border border-black px-4 py-2">Date from Creation</th>
           <th class="border border-black px-4 py-2">View</th>
 
         </tr>
@@ -107,7 +108,19 @@
             <td class="border border-black px-4 py-2"><%= ticket.issues.order(created_at: :desc).first&.created_at&.strftime('%d/%b/%Y %I:%M:%S %p') || 'N/A' %></td>
             <td class="border border-black px-4 py-2"><%= ticket.issues.order(created_at: :desc).first&.content&.to_plain_text&.truncate(800) || 'N/A' %></td>
             <td class="border border-black px-4 py-2"><%= ticket.due_date&.strftime('%d/%b/%Y') || 'N/A' %></td>
-            <td class="border border-black px-4 py-2">
+          <td class="border border-black px-4 py-2">
+            <% closed_status = ticket.add_statuses.joins(:status).where(statuses: { name: %w[Closed Resolved Declined] }).order(updated_at: :desc).first %>
+            <% if ticket.created_at %>
+              <% if closed_status %>
+                <%= distance_of_time_in_words(ticket.created_at, closed_status.updated_at).gsub('about ', '') %>
+              <% else %>
+                <%= distance_of_time_in_words(ticket.created_at, Time.current).gsub('about ', '') %>
+              <% end %>
+            <% else %>
+              N/A
+            <% end %>
+          </td>
+          <td class="border border-black px-4 py-2">
               <%= link_to 'VIEW', project_ticket_path(ticket.project, ticket), target: "_blank", class: 'bg-[#3F8CFF] hover:bg-[#3A81EB] p-2 rounded font-bold rounded-md text-slate-100' %>
             </td>
         </tr>

--- a/app/views/product/new.html.erb
+++ b/app/views/product/new.html.erb
@@ -192,7 +192,7 @@
   })
 
   // Character counter for description
-  document.addEventListener('DOMContentLoaded', function() {
+  document.addEventListener('turbo:load', function() {
     const contentField = document.querySelector('[data-text-limit-target="content"]');
     const charCount = document.getElementById('char-count');
     

--- a/app/views/user_mailer/daily_ticket_email.html.erb
+++ b/app/views/user_mailer/daily_ticket_email.html.erb
@@ -45,6 +45,7 @@
       <th>Service Desk</th>
       <th>Summary</th>
       <th>Status</th>
+      <th>Days Taken</th>
     </tr>
     </thead>
     <tbody>
@@ -56,6 +57,18 @@
         <td><%= ticket.project.title %></td>
         <td><%= ticket.subject %></td>
         <td><%= ticket.statuses.first&.name || 'N/A' %></td>
+        <td>
+          <% closed_status = ticket.add_statuses.joins(:status).where(statuses: { name: %w[Closed Resolved Declined] }).order(updated_at: :desc).first %>
+          <% if ticket.created_at %>
+            <% if closed_status %>
+              <%= distance_of_time_in_words(ticket.created_at, closed_status.updated_at).gsub('about ', '') %>
+            <% else %>
+              <%= distance_of_time_in_words(ticket.created_at, Time.current).gsub('about ', '') %>
+            <% end %>
+          <% else %>
+            N/A
+          <% end %>
+        </td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/user_mailer/morning_ticket_email.html.erb
+++ b/app/views/user_mailer/morning_ticket_email.html.erb
@@ -45,6 +45,7 @@
       <th>Service Desk</th>
       <th>Summary</th>
       <th>Status</th>
+      <th>Time Taken</th>
     </tr>
     </thead>
     <tbody>
@@ -56,6 +57,19 @@
         <td><%= ticket.project.title %></td>
         <td><%= ticket.subject %></td>
         <td><%= ticket.statuses.first&.name || 'N/A' %></td>
+        <td>
+          <% closed_status = ticket.add_statuses.joins(:status).where(statuses: { name: %w[Closed Resolved Declined] }).order(updated_at: :desc).first %>
+          <% if ticket.created_at %>
+            <% if closed_status %>
+              <%= distance_of_time_in_words(ticket.created_at, closed_status.updated_at).gsub('about ', '') %>
+            <% else %>
+              <%= distance_of_time_in_words(ticket.created_at, Time.current).gsub('about ', '') %>
+            <% end %>
+          <% else %>
+            N/A
+          <% end %>
+        </td>
+
       </tr>
     <% end %>
     </tbody>

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,7 +2,7 @@
 
 
 Sentry.init do |config|
-  config.dsn = 'https://c8d22bdb73eb46303a666a15221e86ea@o4507601057808384.ingest.de.sentry.io/4508040944615504'
+  config.dsn = 'https://85203d40eceb93e298941a2cce089ebd@o4507601057808384.ingest.de.sentry.io/4509802193354832'
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
   # Set traces_sample_rate to 1.0 to capture 100%


### PR DESCRIPTION
This pull request introduces two small but important changes: it updates the default status assigned to new products and improves the reliability of the character counter on the new product form.

Product status initialization:

* Changed the default status assigned in the `Product` model from `'Development'` to `'Initiation'` when a new product is created.

Frontend behavior:

* Updated the event listener in `product/new.html.erb` to use `'turbo:load'` instead of `'DOMContentLoaded'`, ensuring the character counter works correctly with Turbo navigation.