### PR TITLE
Setup the correct deployment

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -28,9 +28,9 @@ install_plugin Capistrano::SCM::Git
 #
 # require "capistrano/rvm"
 # require "capistrano/chruby"
-require "capistrano/bundler"
-require "capistrano/rails/assets"
-require "capistrano/rails/migrations"
+require 'capistrano/bundler'
+require 'capistrano/rails/assets'
+require 'capistrano/rails/migrations'
 require 'capistrano/rbenv'
 require 'capistrano/rails'
 require 'capistrano/passenger'

--- a/Capfile
+++ b/Capfile
@@ -28,9 +28,9 @@ install_plugin Capistrano::SCM::Git
 #
 # require "capistrano/rvm"
 # require "capistrano/chruby"
-# require "capistrano/bundler"
-# require "capistrano/rails/assets"
-# require "capistrano/rails/migrations"
+require "capistrano/bundler"
+require "capistrano/rails/assets"
+require "capistrano/rails/migrations"
 require 'capistrano/rbenv'
 require 'capistrano/rails'
 require 'capistrano/passenger'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,15 +1,15 @@
 # config valid for current version and patch releases of Capistrano
 lock "~> 3.19.1"
 
-set :application, "CSPM"
-set :repo_url, "https://github.com/ger619/CSPM.git"
+set :application, "TaskBridge"
+set :repo_url, "https://github.com/Kanyorok/TaskBridgeApp.git"
 set :branch, 'dev'
 
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 
 # Default deploy_to directory is /var/www/my_app_name
-set :deploy_to, "/home/deploy/#{fetch(:application)}"
+set :deploy_to, "/home/taskbridgetest/#{fetch(:application)}"
 
 # Default value for :format is :airbrussh.
 # set :format, :airbrussh

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -5,6 +5,9 @@
 
 server "172.17.40.11", user: "deploy", roles: %w{app db web}
 
+set :rails_env, "production"
+set :branch, "dev" 
+
 # server "example.com", user: "deploy", roles: %w{web}, other_property: :other_value
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,0 +1,4 @@
+server "172.16.2.15", user: "taskbridgetest", roles: %w{app db web}
+
+set :rails_env, "staging"
+set :branch, "dev"  # Or whatever branch you deploy to staging


### PR DESCRIPTION
This pull request updates the Capistrano deployment configuration to support the new `TaskBridge` application and streamlines the deployment process for both production and staging environments. The changes include updating project references, deployment paths, enabling essential Capistrano plugins, and adding environment-specific configuration.

**Project and deployment configuration updates:**

* Changed the application name from `"CSPM"` to `"TaskBridge"` and updated the repository URL to `https://github.com/Kanyorok/TaskBridgeApp.git` in `config/deploy.rb`. The deployment directory was also updated to use the `taskbridgetest` user.

**Capistrano plugin activation:**

* Enabled `capistrano/bundler`, `capistrano/rails/assets`, and `capistrano/rails/migrations` plugins in `Capfile` to ensure proper asset management and dependency installation during deployment.

**Environment-specific deployment settings:**

* Added staging environment configuration in `config/deploy/staging.rb`, specifying the server, deployment user, Rails environment, and branch.
* Set `rails_env` to `"production"` and enforced deployment from the `dev` branch in `config/deploy/production.rb`.